### PR TITLE
feat(cli): add shell completions support and update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,22 @@ performance baselines.
 
 ## Installation
 
+### Using Homebrew (macOS/Linux)
+
+```shell
+brew install httptap
+```
+
 ### Using `uv`
 
 ```shell
 uv pip install httptap
+```
+
+### Using `pip`
+
+```shell
+pip install httptap
 ```
 
 ### From source
@@ -88,16 +100,34 @@ cd httptap
 uv venv
 uv pip install .
 ```
+
 ---
 
 ### Shell completions
 
-To enable shell completions for bash and zsh, install the optional extras and activate the completion helper in your virtual environment:
+#### Homebrew Installation
 
-1. Install the extras:
+If you installed httptap via Homebrew, shell completions are automatically available after installation. Just restart your shell:
+
+```shell
+# Restart your shell or reload configuration
+exec $SHELL
+```
+
+Homebrew automatically installs completions to:
+- Bash: `$(brew --prefix)/etc/bash_completion.d/`
+- Zsh: `$(brew --prefix)/share/zsh/site-functions/`
+
+#### Python Package Installation
+
+If you installed httptap via `pip` or `uv`, you need to install the optional completion extras:
+
+1. Install the completion extras:
 
    ```shell
-   uv pip install "httptap[extras]"
+   uv pip install "httptap[completion]"
+   # or
+   pip install "httptap[completion]"
    ```
 
 2. Activate your virtual environment:
@@ -106,19 +136,33 @@ To enable shell completions for bash and zsh, install the optional extras and ac
    source .venv/bin/activate
    ```
 
-
-3. Run the global activation script for argument completions and then restart your shell:
+3. Run the global activation script for argument completions:
 
    ```shell
-   # installs/activates the system-wide argcomplete hook
    activate-global-python-argcomplete
    ```
 
 4. Restart your shell. Completions should now work in both bash and zsh.
 
+**Note:** The global activation script provides argument completions for bash and zsh only. Other shells are not covered by the script and must be configured separately.
 
-  - Note: The global activation script provides argument completions for bash and zsh only. Other shells are not covered by the script and must be configured separately.
+#### Usage Examples
 
+Once completions are installed, you can use `Tab` to autocomplete commands and options:
+
+```shell
+# Complete command options
+httptap --<TAB>
+# Shows: --follow, --timeout, --no-http2, --ignore-ssl, --proxy, --header, --compact, --metrics-only, --json, --version, --help
+
+# Complete after typing partial option
+httptap --fol<TAB>
+# Completes to: httptap --follow
+
+# Complete multiple options
+httptap --follow --time<TAB>
+# Completes to: httptap --follow --timeout
+```
 
 ---
 
@@ -419,7 +463,7 @@ We welcome bug reports, feature proposals, doc improvements, and creative new vi
 
 ## License
 
-Apache License 2.0 © httptap contributors. See [LICENSE](https://github.com/ozeranskii/httptap/blob/main/LICENSE) for
+Apache License 2.0 © Sergei Ozeranskii. See [LICENSE](https://github.com/ozeranskii/httptap/blob/main/LICENSE) for
 details.
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,6 +10,23 @@ Before installing httptap, ensure you have:
 
 No system dependencies beyond standard networking are required.
 
+## Installing via Homebrew
+
+=== "macOS"
+
+    ```bash
+    brew install httptap
+    ```
+
+=== "Linux"
+
+    ```bash
+    brew install httptap
+    ```
+
+!!! tip "Recommended for macOS/Linux users"
+    Homebrew installation is the simplest method and includes automatic shell completion setup.
+
 ## Installing from PyPI
 
 === "Using uv (recommended)"
@@ -80,6 +97,12 @@ httptap X.Y.Z
 
 To upgrade httptap to the latest version:
 
+=== "Using Homebrew"
+
+    ```bash
+    brew upgrade httptap
+    ```
+
 === "Using uv"
 
     ```bash
@@ -95,6 +118,12 @@ To upgrade httptap to the latest version:
 ## Uninstalling
 
 To remove httptap from your system:
+
+=== "Using Homebrew"
+
+    ```bash
+    brew uninstall httptap
+    ```
 
 === "Using uv"
 
@@ -113,6 +142,87 @@ To remove httptap from your system:
     ```bash
     pipx uninstall httptap
     ```
+
+---
+
+## Shell Completions
+
+httptap supports shell completions for bash and zsh.
+
+### Homebrew Installation
+
+If you installed httptap via Homebrew, **completions are automatically configured**. Simply restart your shell:
+
+```bash
+# Restart your shell
+exec $SHELL
+```
+
+Homebrew automatically places completion scripts in:
+
+- **Bash**: `$(brew --prefix)/etc/bash_completion.d/`
+- **Zsh**: `$(brew --prefix)/share/zsh/site-functions/`
+
+!!! success "No additional setup required"
+    Homebrew handles all completion setup automatically. Just restart your shell and start using Tab completion!
+
+### Python Package Installation
+
+If you installed httptap via `pip`, `uv`, or `pipx`, you need to install the optional `completion` extras:
+
+=== "Using uv"
+
+    ```bash
+    uv pip install "httptap[completion]"
+    ```
+
+=== "Using pip"
+
+    ```bash
+    pip install "httptap[completion]"
+    ```
+
+=== "Using pipx"
+
+    ```bash
+    pipx install "httptap[completion]"
+    ```
+
+#### Activation
+
+1. Activate your virtual environment (if using venv):
+
+    ```bash
+    source .venv/bin/activate
+    ```
+
+2. Run the global activation script:
+
+    ```bash
+    activate-global-python-argcomplete
+    ```
+
+3. Restart your shell.
+
+### Usage
+
+Once installed and activated, you can use `Tab` to autocomplete commands and options:
+
+```bash
+# Complete command options
+httptap --<TAB>
+
+# Complete after typing partial option
+httptap --fol<TAB>
+# Completes to: httptap --follow
+
+# Complete multiple options
+httptap --follow --time<TAB>
+# Completes to: httptap --follow --timeout
+```
+
+!!! note
+    The global activation script provides argument completions for bash and zsh only. Other shells are not covered by the script and must be configured separately.
 
 ---
 

--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -31,13 +31,58 @@ httptap \
 
 #### `--follow`
 
-Follow HTTP redirects and show timing for each step in the chain.
+Follow HTTP redirects and show timing for each step in the chain (max 10 redirects).
 
 ```bash
 httptap --follow https://httpbin.io/redirect/3
 ```
 
 By default, httptap does not follow redirects and will stop at the first redirect response (3xx status code).
+
+#### `--timeout SECONDS`
+
+Abort the request chain if total elapsed time exceeds the specified number of seconds.
+
+```bash
+httptap --timeout 10 https://httpbin.io/delay/2
+```
+
+Default timeout is 20 seconds.
+
+#### `--no-http2`
+
+Disable HTTP/2 negotiation and force HTTP/1.1 connections.
+
+```bash
+httptap --no-http2 https://httpbin.io
+```
+
+By default, HTTP/2 is enabled if the server supports it.
+
+#### `--ignore-ssl`
+
+Disable TLS certificate verification. Useful for debugging self-signed hosts or expired certificates.
+
+```bash
+httptap --ignore-ssl https://self-signed.badssl.com
+```
+
+!!! warning
+    Use this option only on trusted networks. It disables certificate validation and relaxes handshake constraints.
+
+#### `--proxy URL`
+
+Route requests through the specified proxy. Supports HTTP, HTTPS, SOCKS5, and SOCKS5H protocols.
+
+```bash
+# HTTP proxy
+httptap --proxy http://proxy.example.com:8080 https://httpbin.io
+
+# SOCKS5 proxy
+httptap --proxy socks5h://proxy.local:1080 https://example.com
+```
+
+The proxy setting takes precedence over environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`).
 
 ### Output Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-extras = [
+completion = [
     "argcomplete>=3.6.3",
 ]
-
 
 [project.scripts]
 httptap = "httptap.cli:main"
@@ -100,6 +99,7 @@ dev = [
 
 typing = [
     "mypy>=1.18.2",
+    "argcomplete>=3.6.3",
 ]
 
 test = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import signal
 from argparse import Namespace
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import pytest
 from typing_extensions import Self
@@ -103,7 +103,7 @@ class RendererStub:
 
 def test_main_success(monkeypatch: pytest.MonkeyPatch) -> None:
     analyzer = AnalyzerStub()
-    captured_ctor: dict[str, object] = {}
+    captured_ctor: dict[str, Any] = {}
     renderer = RendererStub()
 
     def fake_analyzer(*_args: object, **kwargs: object) -> AnalyzerStub:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ssl
 from types import SimpleNamespace, TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
@@ -875,7 +875,7 @@ class TestMakeRequest:
     ) -> None:
         url = "https://proxy.test"
         proxy_url = "socks5://gateway:1080"
-        created_clients: list[DummyClient] = []
+        created_clients: list[Any] = []
 
         class DummyClient:
             def __init__(self, *_: object, **kwargs: object) -> None:

--- a/tests/test_request_executor.py
+++ b/tests/test_request_executor.py
@@ -15,7 +15,7 @@ class SignatureFailsExecutor:
         self.calls: list[dict[str, object]] = []
 
     @property
-    def __signature__(self) -> None:  # type: ignore[override]
+    def __signature__(self) -> None:
         msg = "signature unavailable"
         raise ValueError(msg)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -301,8 +301,8 @@ class TestCreateSSLContext:
         ctx = create_ssl_context(verify_ssl=False)
 
         assert ctx.verify_mode == ssl.CERT_NONE
-        assert ctx.minimum_version == "original-min"
-        assert ctx.maximum_version == "original-max"
+        assert ctx.minimum_version == "original-min"  # type: ignore[comparison-overlap]
+        assert ctx.maximum_version == "original-max"  # type: ignore[comparison-overlap]
 
     def test_create_ssl_context_without_disable_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Function handles environments lacking OP_NO_* constants."""

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-extras = [
+completion = [
     { name = "argcomplete" },
 ]
 
@@ -564,17 +564,18 @@ test = [
     { name = "pytest-mock" },
 ]
 typing = [
+    { name = "argcomplete" },
     { name = "mypy" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "argcomplete", marker = "extra == 'extras'", specifier = ">=3.6.3" },
+    { name = "argcomplete", marker = "extra == 'completion'", specifier = ">=3.6.3" },
     { name = "dnspython", specifier = ">=2.8.0" },
     { name = "httpx", extras = ["http2", "socks"], specifier = ">=0.28.1" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
-provides-extras = ["extras"]
+provides-extras = ["completion"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -598,7 +599,10 @@ test = [
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
 ]
-typing = [{ name = "mypy", specifier = ">=1.18.2" }]
+typing = [
+    { name = "argcomplete", specifier = ">=3.6.3" },
+    { name = "mypy", specifier = ">=1.18.2" },
+]
 
 [[package]]
 name = "httpx"
@@ -835,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.6.22"
+version = "9.6.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -850,9 +854,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/5d/317e37b6c43325cb376a1d6439df9cc743b8ee41c84603c2faf7286afc82/mkdocs_material-9.6.22.tar.gz", hash = "sha256:87c158b0642e1ada6da0cbd798a3389b0bc5516b90e5ece4a0fb939f00bacd1c", size = 4044968, upload-time = "2025-10-15T09:21:15.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/de/cc1d5139c2782b1a49e1ed1845b3298ed6076b9ba1c740ad7c952d8ffcf9/mkdocs_material-9.6.23.tar.gz", hash = "sha256:62ebc9cdbe90e1ae4f4e9b16a6aa5c69b93474c7b9e79ebc0b11b87f9f055e00", size = 4048130, upload-time = "2025-11-01T16:33:11.782Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/82/6fdb9a7a04fb222f4849ffec1006f891a0280825a20314d11f3ccdee14eb/mkdocs_material-9.6.22-py3-none-any.whl", hash = "sha256:14ac5f72d38898b2f98ac75a5531aaca9366eaa427b0f49fc2ecf04d99b7ad84", size = 9206252, upload-time = "2025-10-15T09:21:12.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/df/bc583e857174b0dc6df67d555123533f09e7e1ac0f3fae7693fb6840c0a3/mkdocs_material-9.6.23-py3-none-any.whl", hash = "sha256:3bf3f1d82d269f3a14ed6897bfc3a844cc05e1dc38045386691b91d7e6945332", size = 9210689, upload-time = "2025-11-01T16:33:08.196Z" },
 ]
 
 [package.optional-dependencies]
@@ -1443,7 +1447,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.35.3"
+version = "20.35.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1451,9 +1455,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/d5/b0ccd381d55c8f45d46f77df6ae59fbc23d19e901e2d523395598e5f4c93/virtualenv-20.35.3.tar.gz", hash = "sha256:4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44", size = 6002907, upload-time = "2025-10-10T21:23:33.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/73/d9a94da0e9d470a543c1b9d3ccbceb0f59455983088e727b8a1824ed90fb/virtualenv-20.35.3-py3-none-any.whl", hash = "sha256:63d106565078d8c8d0b206d48080f938a8b25361e19432d2c9db40d2899c810a", size = 5981061, upload-time = "2025-10-10T21:23:30.433Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This pr implements shell completions.

Fixes #31 

## Type of Change


- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test improvements
- [ ] 🔧 Build/CI/tooling changes

## Changes Made


- added dependency argcomplete
- Implemented optional importing


## Testing

Testing is skipped as not relevant for added lines of code. 

**Test environment:**

- OS: Ubuntu 
- Python version: 3.12.3
- httptap version: 0.2.0

**Tests performed:**

- [x] Ran existing test suite: `uv run pytest`
- [ ] Added new tests for new functionality
- [x] Manually tested with: `httptap <command>`
Tested only on linux, required manual test on macos

**Test commands:**

```bash
# Example commands used to verify the changes
httptap --<TAB>
```

**Expected behavior:**
Shell supposed to provide completions 

**Actual behavior:**
```bash
httptap --
--help          -- show this help message and exit
--version       -- Show the httptap version and exit.
--follow        -- Follow redirects until a non-3xx response is reached (max 10).
--timeout       -- Abort the request chain if total elapsed time exceeds SECONDS.
--no-http2      -- Disable HTTP/2 negotiation and force HTTP/1.1 connections.
--ignore-ssl    -- Disable TLS certificate verification (useful for debugging self-signed hosts).
--proxy         -- Route requests through the given proxy (http://, https://, socks5://, socks5h://).
--header        -- Add a request header (repeatable).
--compact       -- Print one summary line per step instead of the waterfall view.
--metrics-only  -- Emit key=value metrics without Rich visuals or progress spinners.
--json          -- Export the collected metrics, network, and response details to PATH.

```

## Screenshots/Output

<img width="1632" height="438" alt="image" src="https://github.com/user-attachments/assets/0f3207b7-93a9-4cb0-bdcd-5c3b48eedd51" />


## Checklist

<!-- Ensure you've completed these steps before submitting -->

- [x] My code follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
- [x] I have run `uv run ruff check .` and `uv run ruff format .`
- [x] I have run `uv run mypy httptap` and resolved type errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally: `uv run pytest`
- [x] I have updated the documentation (if applicable)
- [ ] I have added docstrings to new functions/classes
- [ ] My changes don't introduce new dependencies (or I've justified them)
- [ ] I have checked that my changes work on multiple platforms (if applicable)

## Problems
1. I had a problem with mypy on lines 57-59 where we violate types and make module variable as none and even if we define this type before specifying that it is optional it complained because of redefenition:
```python
argcomplete: ModuleType | None
try:
    import argcomplete
except ImportError:  # pragma: no cover
    argcomplete = None  # type: ignore[assignment]
    logger.debug("argcomplete is not installed, skipping autocomplete")

```
Manual executions of mypy, linter and pytest are executed normaly, only mypy in pre commit complained. 
