### PR TITLE
style: add trailing commas and modernize isinstance calls

### DIFF
--- a/httptap/cli.py
+++ b/httptap/cli.py
@@ -78,7 +78,7 @@ class RichArgumentParser(argparse.ArgumentParser):
                 title="[bold red]❌ Argument Error[/bold red]",
                 border_style="red",
                 padding=(1, 2),
-            )
+            ),
         )
         self.print_usage(sys.stderr)
         sys.exit(EXIT_USAGE_ERROR)
@@ -352,7 +352,7 @@ def validate_arguments(args: argparse.Namespace) -> bool:
                 title="[bold red]❌ Validation Error[/bold red]",
                 border_style="red",
                 padding=(1, 2),
-            )
+            ),
         )
         return False
 
@@ -369,7 +369,7 @@ def validate_arguments(args: argparse.Namespace) -> bool:
                 title="[bold red]❌ Validation Error[/bold red]",
                 border_style="red",
                 padding=(1, 2),
-            )
+            ),
         )
         return False
 
@@ -381,7 +381,7 @@ def validate_arguments(args: argparse.Namespace) -> bool:
                 str(exc),
                 title="[bold red]❌ Header Error[/bold red]",
                 border_style="red",
-            )
+            ),
         )
         return False
 
@@ -397,7 +397,7 @@ def validate_arguments(args: argparse.Namespace) -> bool:
                     title="[bold red]❌ Validation Error[/bold red]",
                     border_style="red",
                     padding=(1, 2),
-                )
+                ),
             )
             return False
         args.ca_bundle = str(Path(ca_bundle_str).expanduser().absolute())

--- a/httptap/http_client.py
+++ b/httptap/http_client.py
@@ -308,7 +308,7 @@ _PROXY_URL_ENV_VARS: frozenset[str] = frozenset(
         "HTTPS_PROXY",
         "all_proxy",
         "ALL_PROXY",
-    }
+    },
 )
 
 
@@ -584,7 +584,7 @@ def make_request(  # noqa: C901, PLR0912, PLR0915, PLR0913
                 request_url += f"?{parsed_url.query}"
 
             with client.stream(
-                method.value, request_url, content=content, extensions={"trace": trace, "sni_hostname": host}
+                method.value, request_url, content=content, extensions={"trace": trace, "sni_hostname": host},
             ) as response:
                 timing_collector.mark_ttfb()
                 _populate_response_metadata(response, response_info)
@@ -697,6 +697,6 @@ def _extract_ssl_object(
     except Exception:  # pragma: no cover - defensive  # noqa: BLE001
         return None
 
-    if isinstance(ssl_candidate, (ssl.SSLSocket, ssl.SSLObject, SSLInfoProvider)):
+    if isinstance(ssl_candidate, ssl.SSLSocket | ssl.SSLObject | SSLInfoProvider):
         return ssl_candidate
     return None

--- a/tests/test_request_executor.py
+++ b/tests/test_request_executor.py
@@ -14,7 +14,7 @@ def test_http_client_executor_delegates_to_make_request(monkeypatch: pytest.Monk
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -61,7 +61,7 @@ def test_http_client_executor_with_socks5h_proxy(monkeypatch: pytest.MonkeyPatch
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -89,7 +89,7 @@ def test_http_client_executor_with_http_proxy(monkeypatch: pytest.MonkeyPatch) -
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -117,7 +117,7 @@ def test_http_client_executor_with_https_proxy(monkeypatch: pytest.MonkeyPatch) 
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -145,7 +145,7 @@ def test_http_client_executor_with_socks5_proxy(monkeypatch: pytest.MonkeyPatch)
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -173,7 +173,7 @@ def test_http_client_executor_with_authenticated_proxy(monkeypatch: pytest.Monke
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout
@@ -201,7 +201,7 @@ def test_http_client_executor_without_proxy(monkeypatch: pytest.MonkeyPatch) -> 
     captured: dict[str, object] = {}
 
     def fake_make_request(
-        url: str, timeout: float, **kwargs: object
+        url: str, timeout: float, **kwargs: object,
     ) -> tuple[TimingMetrics, NetworkInfo, ResponseInfo]:
         captured["url"] = url
         captured["timeout"] = timeout


### PR DESCRIPTION
Closing this PR — after reflection, this was premature. The automated fixes are mechanically correct but this project isn't ready for external contributions yet. Apologies for the noise. Feel free to run `ruff check . --select COM812,UP038 --fix` if you'd like these changes independently.