### PR TITLE
feat(cli): add --slo threshold checking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,16 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
+      - name: Attach VEX document
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # OpenVEX is kept in-tree under .vex/ so every commit tracks
+          # the current exploitability assessment. Rename-copy the file
+          # with the release version embedded so the published artifact
+          # is self-identifying.
+          cp .vex/httptap.openvex.json "sbom/${PACKAGE_NAME}-${VERSION}.openvex.json"
+
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.vex/README.md
+++ b/.vex/README.md
@@ -1,0 +1,75 @@
+# VEX (Vulnerability Exploitability eXchange) documents
+
+This directory holds the project's VEX document
+([`httptap.openvex.json`](./httptap.openvex.json)) in the
+[OpenVEX](https://github.com/openvex/spec) format.
+
+A VEX document describes, for each known vulnerability that has been
+reported against one of the project's dependencies, whether the project
+itself is actually affected. Automated scanners read VEX alongside the
+SBOM to suppress false-positive alerts when the vulnerable code path
+is not reachable from `httptap`.
+
+## When to update
+
+Open a pull request touching `httptap.openvex.json` whenever:
+
+- A new CVE is published against a direct or transitive dependency of
+  `httptap` (watch GitHub Security Advisories and Dependabot alerts).
+- An existing VEX statement needs to be revised (e.g., status changes
+  from `under_investigation` to `not_affected` after analysis).
+
+Always bump the top-level `"version"` field and the `"timestamp"`
+field to the current UTC time when you amend the document, per the
+OpenVEX specification.
+
+## Status and justification vocabulary
+
+Each entry uses one of four OpenVEX statuses:
+
+| Status                | Meaning                                                      |
+|-----------------------|--------------------------------------------------------------|
+| `not_affected`        | httptap is not affected; a justification is required.        |
+| `affected`            | httptap is affected; an `action_statement` should follow.    |
+| `fixed`               | httptap released a fix; point at the fixed version.          |
+| `under_investigation` | Analysis in progress.                                        |
+
+For `not_affected`, the OpenVEX vocabulary of justifications is:
+
+- `component_not_present`
+- `vulnerable_code_not_present`
+- `vulnerable_code_not_in_execute_path`
+- `vulnerable_code_cannot_be_controlled_by_adversary`
+- `inline_mitigations_already_exist`
+
+## Example statement
+
+```json
+{
+  "vulnerability": {"name": "CVE-2099-0001"},
+  "products": [
+    {
+      "@id": "pkg:pypi/httptap@0.4.8",
+      "subcomponents": [{"@id": "pkg:pypi/httpx@0.28.1"}]
+    }
+  ],
+  "status": "not_affected",
+  "justification": "vulnerable_code_not_in_execute_path",
+  "impact_statement": "httptap does not call the vulnerable API."
+}
+```
+
+## Distribution
+
+The VEX document is attached to every GitHub Release alongside the
+CycloneDX and SPDX SBOMs, so end-users can verify the contents
+without cloning the repository:
+
+- [Latest release assets](https://github.com/ozeranskii/httptap/releases/latest)
+
+Verification:
+
+```shell
+gh release download v0.4.8 --pattern 'httptap*.openvex.json'
+jq . httptap-0.4.8.openvex.json
+```

--- a/.vex/httptap.openvex.json
+++ b/.vex/httptap.openvex.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/ozeranskii/httptap/.vex/httptap.openvex.json",
+  "author": "Sergei Ozeranskii",
+  "role": "project maintainer",
+  "timestamp": "2026-04-12T00:00:00Z",
+  "version": 1,
+  "tooling": "manual",
+  "statements": []
+}

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -90,7 +90,11 @@ Releases are cut by the maintainer using the automated release workflow in
   Publishing (no long-lived API tokens).
 - **Supply chain:** releases are signed with Sigstore keyless signing and
   ship SLSA v1.0 build provenance attestations via
-  `actions/attest-build-provenance`.
+  `actions/attest-build-provenance`. Each release also attaches a
+  CycloneDX + SPDX SBOM and the current OpenVEX document from
+  [`.vex/httptap.openvex.json`](.vex/httptap.openvex.json) so that
+  downstream scanners can triage dependency CVEs against the actual
+  exploitability of `httptap`.
 - **Supported versions:** see [SECURITY.md](SECURITY.md).
 
 ## Continuity

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ performance baselines.
   - [Redirects and JSON Export](#redirects-and-json-export)
   - [Output Modes](#output-modes)
   - [Advanced Usage](#advanced-usage)
+- [SLO Threshold Checking](#slo-threshold-checking)
 - [Environment Variables](#environment-variables)
 - [Exit Codes](#exit-codes)
 - [Releasing](#releasing)
@@ -109,6 +110,8 @@ performance baselines.
 - **TLS insights** – certificate CN, expiry countdown, cipher suite, and protocol version are captured automatically.
 - **Multiple output modes** – rich waterfall view, compact single-line summaries, or `--metrics-only` for scripting.
 - **JSON export** – persist full step data (including redirect chains) for later processing.
+- **SLO threshold checking** – `--slo total=500,ttfb=200` gates CI jobs, cron probes, and readiness checks on per-phase
+  latency budgets; non-zero exit on violation while still rendering the full report.
 - **Extensible** – clean Protocol interfaces for DNS, TLS, timing, visualization, and export so you can plug in custom
   behavior.
 
@@ -125,7 +128,7 @@ performance baselines.
 | Redirect chain with per-step timing      | ✅        | ❌                     | ❌                                              | ❌                |
 | JSON export (machine-readable)           | ✅        | ✅ (`-w '%{json}'`)    | ✅ (`--format json/jsonl`, v1 schema)           | ❌ (no metrics)   |
 | Metrics-only mode for scripting          | ✅        | ✅                     | ✅ (`--format json`)                            | ❌                |
-| SLO threshold checking                   | ❌        | ❌                     | ✅ (`--slo total=500,...`)                      | ❌                |
+| SLO threshold checking                   | ✅ (`--slo`) | ❌                  | ✅ (`--slo total=500,...`)                      | ❌                |
 | TLS certificate inspection (CN, expiry)  | ✅        | ⚠️ via `-v`            | ❌                                              | ❌                |
 | IPv4/IPv6 reporting                      | ✅ family | ⚠️ IP via `remote_ip`  | ⚠️ IP only (`remote_ip`/`remote_port`)          | ❌                |
 | HTTP/2 support                           | ✅        | ✅                     | ⚠️ via curl passthrough                         | ⚠️ plugin only    |
@@ -382,6 +385,49 @@ can confirm what path was used (e.g., `(from arg --proxy)`,
 
 ---
 
+## SLO Threshold Checking
+
+Gate CI jobs, cron probes, and Kubernetes readiness checks on per-phase
+latency budgets with `--slo KEY=MS[,KEY=MS...]`:
+
+```shell
+httptap --slo total=500,ttfb=200 https://api.example.com/health
+```
+
+- Exits `0` when every threshold passes.
+- Exits `4` when at least one threshold is exceeded on the **final
+  successful step** (intermediate redirects are not evaluated).
+- Exits `64` on malformed specification (unknown key, duplicate key,
+  non-positive value, bad syntax).
+- The full waterfall / compact / JSON output is always rendered so the
+  evidence for a regression is preserved.
+
+Supported keys: `dns`, `connect`, `tls`, `ttfb`, `wait`, `xfer`, `total`.
+
+Output extensions:
+
+- **Rich / compact** — a bordered panel after the waterfall lists the
+  thresholds and any violations (actual, threshold, overrun).
+- **`--metrics-only`** — the final successful step carries `slo=pass`
+  or `slo=fail slo_violations=<keys>` tokens.
+- **`--json`** — the `summary.slo` block contains `pass`,
+  `thresholds_ms`, and per-violation `{key, threshold_ms, actual_ms, delta_ms}`.
+
+```shell
+# CI gate — fail only on SLO violation, tolerate transient network errors
+httptap --slo total=2000,tls=300,ttfb=800 https://staging.example.com/
+case $? in
+  0) echo "healthy" ;;
+  4) echo "SLO violation"; exit 1 ;;
+  75) echo "network flake, retrying later" ;;
+esac
+```
+
+Full specification, evaluation rules, and recipes:
+[docs.httptap.dev/usage/slo](https://docs.httptap.dev/usage/slo/).
+
+---
+
 ## Environment Variables
 
 httptap reads the following environment variables at runtime. All of them are
@@ -412,6 +458,7 @@ shell pipelines, CI jobs, and systemd services.
 | Code  | Symbol                  | Meaning                                                    |
 |:-----:|-------------------------|------------------------------------------------------------|
 | `0`   | `EX_OK`                 | Success.                                                   |
+| `4`   | —                       | SLO threshold violation (request succeeded but too slow).  |
 | `64`  | `EX_USAGE`              | Invalid command-line arguments.                            |
 | `70`  | `EX_SOFTWARE`           | Internal error (unexpected exception, bug).                |
 | `75`  | `EX_TEMPFAIL`           | Network / TLS error (partial output may still be rendered). |
@@ -450,8 +497,9 @@ fi
    - Run full test suite on the tagged version
    - Build wheel and source distribution
    - Generate SBOM in CycloneDX and SPDX formats via Syft
+   - Attach the current OpenVEX document (`.vex/httptap.openvex.json`)
    - Publish to PyPI via Trusted Publishing (OIDC)
-   - Create GitHub Release with wheel, sdist, and SBOM assets
+   - Create GitHub Release with wheel, sdist, SBOM, and VEX assets
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,9 @@ materialize when the maintainer or a contributor actually picks them up.
 - **Output formats** — additional machine-readable exporters (e.g.,
   Prometheus text format, OpenTelemetry traces) when driven by a concrete
   user need.
+- **SLO extensions** — relative budgets (e.g., `total=+20%` against a
+  baseline), SLO-file loading (`--slo-file slo.yaml`), soft vs hard
+  SLO distinction. Core `--slo` key=ms checker already shipped.
 - **Protocol support** — minor improvements to HTTP/1.1 and HTTP/2 behavior
   as upstream (`httpx`, `httpcore`) gains features; potential support for
   HTTP/3 if and when stable Python support lands.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,10 +101,24 @@ When a security vulnerability is fixed:
 2. **Security Advisory**: We create a GitHub Security Advisory
 3. **Patch Release**: We release a new version with the fix
 4. **Changelog Update**: We document the fix in CHANGELOG.md
-5. **User Notification**: We notify users via:
+5. **VEX Update**: We revise `.vex/httptap.openvex.json` so scanners reflect the latest exploitability assessment (see below)
+6. **User Notification**: We notify users via:
    - GitHub Release notes
    - Security Advisory
    - Dependabot alerts (for users using our package)
+
+## VEX (Vulnerability Exploitability eXchange)
+
+Alongside the SBOM, every GitHub Release ships an
+[OpenVEX](https://github.com/openvex/spec) document
+(`httptap-X.Y.Z.openvex.json`). It records, for every CVE that affects
+one of our dependencies, whether `httptap` is actually exploitable —
+so automated scanners can suppress false-positive alerts when the
+vulnerable code path is unreachable from this project.
+
+The source of truth is [`.vex/httptap.openvex.json`](.vex/httptap.openvex.json);
+see [`.vex/README.md`](.vex/README.md) for the update workflow and the
+OpenVEX status/justification vocabulary we use.
 
 ## Security Best Practices for Users
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -255,6 +255,48 @@ exporter = JSONExporter(Console())
 exporter.export(steps, "https://httpbin.io", "output.json")
 ```
 
+## SLO Evaluation
+
+The SLO module is exposed at the package root so programmatic callers
+can parse, evaluate, and serialize latency budgets the same way the
+CLI does.
+
+```python
+from httptap import HTTPTapAnalyzer, evaluate_slo, parse_slo_spec, select_step_for_evaluation
+
+analyzer = HTTPTapAnalyzer(follow_redirects=True)
+steps = analyzer.analyze_url("https://api.example.com/health")
+
+thresholds = parse_slo_spec("total=500,ttfb=200")
+target = select_step_for_evaluation(steps)
+if target is not None:
+    result = evaluate_slo(target, thresholds)
+    if not result.passed:
+        for violation in result.violations:
+            print(
+                f"{violation.key}: {violation.actual_ms:.1f}ms "
+                f"> {violation.threshold_ms:g}ms "
+                f"(+{violation.delta_ms:.1f}ms)"
+            )
+```
+
+Key symbols (all importable from `httptap`):
+
+| Symbol                        | Kind       | Purpose                                                    |
+|-------------------------------|------------|------------------------------------------------------------|
+| `SLO_KEYS`                    | frozenset  | Valid phase keys: `dns/connect/tls/ttfb/wait/xfer/total`.  |
+| `parse_slo_spec(raw)`         | function   | Parse `"total=500,ttfb=200"` → `dict[str, float]`.         |
+| `evaluate_slo(step, th)`      | function   | Run thresholds against one `StepMetrics`, return `SLOResult`. |
+| `select_step_for_evaluation(steps)` | function | Pick the final successful step of a chain.              |
+| `SLOSpecError`                | exception  | `ValueError` subclass raised on malformed specifications.  |
+| `SLOResult`                   | dataclass  | `pass`, frozen `thresholds_ms`, tuple of `violations`.     |
+| `SLOViolation`                | dataclass  | `key`, `threshold_ms`, `actual_ms`, `delta_ms`.            |
+
+`SLOResult` is a frozen dataclass; both `thresholds_ms` (read-only
+mapping view) and `violations` (tuple) are immutable. `SLOResult.to_dict()`
+produces the same structure as the `summary.slo` key in the JSON
+export.
+
 ## Request Executor
 
 For fully customized HTTP behavior, implement the `RequestExecutor` protocol.

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -101,6 +101,7 @@ The release workflow is defined in `.github/workflows/release.yml`:
 - Runs full test suite
 - Builds wheel and sdist
 - Generates SBOM in CycloneDX and SPDX JSON formats via [Syft](https://github.com/anchore/syft)
+- Copies the versioned OpenVEX document from `.vex/httptap.openvex.json` into the `sbom/` directory as `httptap-X.Y.Z.openvex.json`
 - Uploads `dist/` and `sbom/` artifacts separately
 
 #### 3. Publish to PyPI
@@ -112,7 +113,7 @@ The release workflow is defined in `.github/workflows/release.yml`:
 
 - Downloads `dist/` and `sbom/` artifacts
 - Creates GitHub release with changelog notes
-- Attaches wheel, sdist, and SBOM (`*.cdx.json`, `*.spdx.json`) assets
+- Attaches wheel, sdist, SBOM (`*.cdx.json`, `*.spdx.json`), and VEX (`*.openvex.json`) assets
 
 ## Changelog Generation
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -142,6 +142,26 @@ The JSON file will contain:
 - Network information (IP, TLS version, certificate details)
 - Response metadata (status, headers, body size)
 - Full redirect chain (if `--follow` is used)
+- SLO evaluation (if `--slo` is supplied)
+
+## SLO Threshold Checking
+
+Gate CI jobs, cron probes, or Kubernetes readiness checks on per-phase
+latency budgets with `--slo`:
+
+```bash
+httptap --slo total=500,ttfb=200 https://httpbin.io/get
+```
+
+Exit code is `0` when every budget passes and `4` when any threshold
+is violated. The full waterfall is still rendered so you can see *why*
+the check failed.
+
+!!! tip "Supported SLO keys"
+    `dns`, `connect`, `tls`, `ttfb`, `wait`, `xfer`, `total` — each
+    maps to a timing phase. See the dedicated
+    [SLO Threshold Checking](../usage/slo.md) page for the full
+    specification and recipes.
 
 ## Common Use Cases
 

--- a/docs/security/assurance-case.md
+++ b/docs/security/assurance-case.md
@@ -167,6 +167,13 @@ Supporting the release-integrity property (SR-5):
   PR.
 - **Dependency tracking**: SBOM in CycloneDX and SPDX formats is
   generated during release and attached as a GitHub Release asset.
+- **Exploitability disclosure**: an OpenVEX document
+  (`httptap-X.Y.Z.openvex.json`) ships alongside the SBOM, declaring
+  for each dependency CVE whether `httptap` is actually affected. The
+  source of truth is versioned in
+  [`.vex/httptap.openvex.json`](https://github.com/ozeranskii/httptap/blob/main/.vex/httptap.openvex.json);
+  scanners that consume VEX (Grype, Trivy, Snyk) use it to suppress
+  false-positive alerts on unreachable vulnerable code paths.
 
 Users can verify a downloaded artifact independently:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -135,7 +135,24 @@ Sources for `proxy`: `direct`, `none` (NO_PROXY hit), `disabled` (`--proxy ""`),
 
 See the [Exit Codes](https://github.com/ozeranskii/httptap#exit-codes) section
 in the README. Typical CI pattern: treat `75` (network / TLS, transient) as
-retryable, fail hard on `64` (usage) and `70` (bug).
+retryable, fail hard on `64` (usage), `70` (bug), and `4` (SLO violation if
+you supplied `--slo`).
+
+### My `--slo` budget is never triggered even though the request is slow.
+
+Check three things:
+
+1. The key you set maps to an actual timing phase. Valid keys are
+   `dns`, `connect`, `tls`, `ttfb`, `wait`, `xfer`, `total` — anything
+   else rejects the command with exit `64` (SLO Error panel).
+2. SLO is evaluated on the **final successful step**, not intermediate
+   redirects. If `--follow` bounced through several hops and the last
+   step was fast, the overall chain total isn't compared. Use `total`
+   against the terminal request's budget, or aggregate manually from
+   `--json` if you need per-step guarantees.
+3. If every step errored, SLO is skipped entirely — the exit code
+   reflects the network failure (usually `75`). No `slo=` token
+   appears in `--metrics-only` output in that case.
 
 ### Can httptap emit Prometheus metrics?
 

--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -211,6 +211,22 @@ The JSON file contains:
 - Network information (IP address, TLS details, certificate info)
 - Response metadata (status, headers, body size)
 - Complete redirect chain (when using `--follow`)
+- SLO evaluation (when `--slo` is supplied)
+
+#### `--slo KEY=MS[,KEY=MS...]`
+
+Check the final successful step against per-phase latency budgets. On
+violation `httptap` still renders the full report but exits with code
+`4` so the result can gate CI jobs, cron probes, or Kubernetes
+readiness checks.
+
+```bash
+httptap --slo total=500,ttfb=200 https://httpbin.io/get
+```
+
+Supported keys: `dns`, `connect`, `tls`, `ttfb`, `wait`, `xfer`,
+`total`. See the dedicated [SLO Threshold Checking](slo.md) page for
+the full specification, exit-code precedence, and CI/cron recipes.
 
 #### `--version`
 

--- a/docs/usage/output-formats.md
+++ b/docs/usage/output-formats.md
@@ -249,6 +249,32 @@ httptap --follow --json chain.json --metrics-only https://bit.ly/example
 
 ---
 
+## SLO Threshold Overlay
+
+`--slo KEY=MS[,KEY=MS...]` augments every output mode with a pass/fail
+verdict evaluated against the final successful request.
+
+- **Rich mode** — a framed panel is printed after the waterfall.
+  The border is green for pass, red for fail, and each violation is
+  listed with actual, threshold, and overrun in milliseconds.
+- **Compact mode** — behaves as Rich mode above; the SLO panel is
+  still printed after the one-line step summaries.
+- **Metrics-only** — the line for the final successful step gains
+  `slo=pass` or `slo=fail slo_violations=<keys>` tokens. Intermediate
+  redirect steps remain unchanged.
+- **JSON** — `summary.slo` contains `pass`, `thresholds_ms`, and
+  `violations[]` (each with `key`, `threshold_ms`, `actual_ms`,
+  `delta_ms`). Absent when `--slo` is not supplied.
+
+A violation makes `httptap` exit with code `4` while still rendering
+the full output, so the evidence is preserved for post-mortem.
+
+See the dedicated [SLO Threshold Checking](slo.md) page for the
+specification grammar, evaluation rules, exit-code precedence, and
+CI / cron recipes.
+
+---
+
 ## What's Next?
 
 <div class="grid cards" markdown>

--- a/docs/usage/slo.md
+++ b/docs/usage/slo.md
@@ -1,0 +1,257 @@
+---
+title: SLO Threshold Checking
+description: Use --slo to gate requests on per-phase latency budgets in CI, cron, and uptime checks.
+---
+
+# SLO Threshold Checking
+
+`httptap --slo` checks measured timings against per-phase latency
+budgets and exits with a non-zero code when any budget is exceeded.
+This turns a single request into a pass/fail probe suitable for CI
+gates, cron-based synthetic monitoring, uptime checks, and
+post-deployment smoke tests — without writing a custom shell parser.
+
+## Quick Example
+
+```shell
+httptap --slo total=500,ttfb=200 https://api.example.com/health
+```
+
+- Exits with `0` when `total_ms ≤ 500` **and** `ttfb_ms ≤ 200`.
+- Exits with `4` when any budget is exceeded.
+- Continues to print the full waterfall and JSON export regardless of
+  the outcome, so investigations are never blocked by the gate.
+
+## Specification Syntax
+
+Pass a comma-separated list of `KEY=MS` pairs to `--slo`:
+
+```
+--slo KEY=MS[,KEY=MS]*
+```
+
+- `KEY` is one of the supported timing phases (case-insensitive).
+- `MS` is a positive finite number of milliseconds (integer or float).
+- Whitespace around keys and values is tolerated.
+
+### Supported keys
+
+| Key       | Meaning                                                        |
+|-----------|----------------------------------------------------------------|
+| `dns`     | DNS resolution time                                            |
+| `connect` | TCP connection establishment                                   |
+| `tls`     | TLS handshake (`0` for plain HTTP)                             |
+| `ttfb`    | Time to first byte (DNS + connect + TLS + server wait)         |
+| `wait`    | Server processing time (`ttfb - (dns + connect + tls)`)        |
+| `xfer`    | Response body transfer time (`total - ttfb`)                   |
+| `total`   | End-to-end request duration                                    |
+
+### Malformed specifications
+
+`--slo` rejects the following and exits with `64` (usage error):
+
+- Empty specification (`--slo ""`).
+- Unknown key (`--slo foo=500` → `Unknown SLO key 'foo'`).
+- Duplicate key (`--slo total=500,total=600`).
+- Non-numeric value (`--slo total=fast`).
+- Zero, negative, or non-finite value (`--slo total=0`, `total=nan`,
+  `total=inf`).
+- Missing `=` (`--slo total500`).
+
+The specific error is printed in a Rich-formatted panel for
+interactive use, and in plain text under `--metrics-only`.
+
+## Evaluation Rules
+
+SLO thresholds are evaluated against the **final successful step** of
+a request chain:
+
+- Single request → checked against that request.
+- Redirect chain (`--follow`) → checked against the terminal response,
+  not the intermediate redirects. The assumption is that users care
+  about what actually served their request.
+- All steps errored → SLO is skipped entirely; the exit code reflects
+  the network failure (see below).
+
+A threshold passes when `actual ≤ threshold`. Equality does **not**
+count as a violation. Violations are reported in alphabetical order of
+their key for deterministic output.
+
+## Exit Codes
+
+`--slo` integrates with the overall exit-code precedence of `httptap`:
+
+| Priority | Condition                               | Exit code |
+|:--------:|-----------------------------------------|:---------:|
+| 1        | Invalid arguments (bad `--slo` spec)    | `64`      |
+| 2        | Network / TLS failure on any step       | `75`      |
+| 3        | Internal error                          | `70`      |
+| 4        | SLO violation on final successful step  | `4`       |
+| 5        | Success                                 | `0`       |
+
+Network errors always take precedence over SLO violations, so a
+failing host does not masquerade as a latency regression in a CI log.
+
+## Output Formats
+
+### Rich (default)
+
+After the waterfall and any redirect summary, `httptap` prints a panel
+summarising the SLO evaluation:
+
+```
+╭───────────────── ✗ SLO: fail ─────────────────╮
+│ Thresholds: total≤500ms, ttfb≤200ms            │
+│ Violations:                                    │
+│   • total: 723.4ms > 500ms (+223.4ms)          │
+│   • ttfb:  315.2ms > 200ms (+115.2ms)          │
+╰────────────────────────────────────────────────╯
+```
+
+The panel border and icon match the status: green `✓` for pass, red
+`✗` for fail.
+
+### Compact
+
+`--compact` prints one human-readable line per step followed by the
+same Rich SLO panel shown under the default mode:
+
+```
+Step 1: 200 GET https://api.example.com | dns=3.3ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=900.0ms | 1.2 KB
+
+╭───────────────── ✗ SLO: fail ─────────────────╮
+│ Thresholds: total≤500ms                        │
+│ Violations:                                    │
+│   • total: 900.0ms > 500ms (+400.0ms)          │
+╰────────────────────────────────────────────────╯
+```
+
+### Metrics-only
+
+`--metrics-only` appends SLO tokens to the standard `key=value` line
+of the final successful step:
+
+```
+Step 1: dns=30.1 connect=97.3 tls=199.0 ttfb=472.2 total=900.0 ... slo=fail slo_violations=total,ttfb
+```
+
+Pass case:
+
+```
+Step 1: ... proxy=direct slo=pass
+```
+
+Intermediate redirect steps do **not** carry SLO tokens, keeping the
+line count unchanged.
+
+### JSON Export
+
+`--json PATH` extends the `summary` block with an `slo` object:
+
+```json
+{
+  "summary": {
+    "total_time_ms": 900.0,
+    "final_status": 200,
+    "final_url": "https://api.example.com/health",
+    "final_bytes": 128,
+    "errors": 0,
+    "slo": {
+      "pass": false,
+      "thresholds_ms": { "total": 500.0, "ttfb": 200.0 },
+      "violations": [
+        {
+          "key": "total",
+          "threshold_ms": 500.0,
+          "actual_ms": 900.0,
+          "delta_ms": 400.0
+        }
+      ]
+    }
+  }
+}
+```
+
+Each violation carries the key, the user-supplied threshold, the
+measured value, and the overrun. `delta_ms` is strictly positive and
+can be used to rank violations by severity.
+
+When no `--slo` flag is passed the `slo` key is absent — the summary
+shape is backward compatible with existing consumers.
+
+## Recipes
+
+### Cron-based synthetic monitoring
+
+```cron
+* * * * * httptap --slo total=1000,ttfb=500 https://api.example.com/health \
+  || curl -X POST https://alerts.example.com/page/oncall
+```
+
+### CI gate after deploy
+
+```yaml
+- name: Smoke-test staging latency
+  run: |
+    httptap --slo total=2000,tls=300,ttfb=800 \
+      https://staging.example.com/
+```
+
+The step fails only on exit `4` or `64`. Network errors (exit `75`)
+can be handled separately:
+
+```yaml
+- name: Smoke-test staging latency
+  id: smoke
+  continue-on-error: true
+  run: httptap --slo total=2000 https://staging.example.com/
+- name: Fail CI only on SLO violation
+  if: steps.smoke.outcome == 'failure' && steps.smoke.conclusion != 'success'
+  run: |
+    if [ "${{ steps.smoke.outputs.exit_code }}" = "4" ]; then
+      echo "SLO violation — failing build."
+      exit 1
+    fi
+```
+
+### Kubernetes readiness probe
+
+```yaml
+readinessProbe:
+  exec:
+    command:
+      - httptap
+      - --slo
+      - total=5000
+      - http://localhost:8080/healthz
+```
+
+### Regression bar
+
+```shell
+httptap --slo total=500,ttfb=200 --json regression.json https://prod.example.com/
+jq '.summary.slo.violations' regression.json
+```
+
+### Multi-host canary
+
+```shell
+for host in prod-eu prod-us prod-ap; do
+  httptap --slo total=1500 "https://${host}.example.com/health" || echo "${host}: SLO miss"
+done
+```
+
+## Tips
+
+- Start with `--slo total=<P95 latency>` and add per-phase budgets
+  once you have baseline data from `--json` exports.
+- `xfer` and `wait` are derived metrics; their sum is bounded by
+  `total`. If you set a `total` budget the individual phases are
+  implicitly capped.
+- Combine with `--timeout`: `--slo` checks latency *after* the
+  request completed; `--timeout` hard-kills a request that hangs. You
+  usually want both.
+- SLO output mirrors
+  [`httpstat`'s `--slo`](https://github.com/reorx/httpstat#slo-thresholds)
+  format (`slo=pass` / `slo=fail` tokens, exit code `4`), so scripts
+  can be used interchangeably.

--- a/httptap/__init__.py
+++ b/httptap/__init__.py
@@ -43,6 +43,15 @@ from .models import (
 )
 from .render import OutputRenderer
 from .request_executor import HTTPClientRequestExecutor, RequestExecutor, RequestOptions, RequestOutcome
+from .slo import (
+    SLO_KEYS,
+    SLOResult,
+    SLOSpecError,
+    SLOViolation,
+    evaluate_slo,
+    parse_slo_spec,
+    select_step_for_evaluation,
+)
 from .visualizer import WaterfallVisualizer
 
 _package_info = get_package_info()
@@ -52,6 +61,7 @@ __author__ = _package_info.author
 __license__ = _package_info.license
 
 __all__ = [
+    "SLO_KEYS",
     "DNSResolutionError",
     "DNSResolver",
     "Exporter",
@@ -65,6 +75,9 @@ __all__ = [
     "RequestOptions",
     "RequestOutcome",
     "ResponseInfo",
+    "SLOResult",
+    "SLOSpecError",
+    "SLOViolation",
     "SocketTLSInspector",
     "StepMetrics",
     "SystemDNSResolver",
@@ -74,4 +87,7 @@ __all__ = [
     "TimingMetrics",
     "Visualizer",
     "WaterfallVisualizer",
+    "evaluate_slo",
+    "parse_slo_spec",
+    "select_step_for_evaluation",
 ]

--- a/httptap/cli.py
+++ b/httptap/cli.py
@@ -27,6 +27,7 @@ from .analyzer import HTTPTapAnalyzer
 from .constants import (
     DEFAULT_TIMEOUT_SECONDS,
     EXIT_CODE_OK,
+    EXIT_CODE_SLO_VIOLATION,
     EXIT_CODE_SOFTWARE,
     EXIT_CODE_TEMPFAIL,
     EXIT_CODE_USAGE,
@@ -35,15 +36,24 @@ from .constants import (
 )
 from .models import StepMetrics
 from .render import OutputRenderer
+from .slo import (
+    SLO_KEYS,
+    SLOResult,
+    SLOSpecError,
+    evaluate_slo,
+    parse_slo_spec,
+    select_step_for_evaluation,
+)
 from .utils import read_request_data, validate_url
 
-# Exit codes (aligned with sysexits.h conventions)
+# Exit codes (aligned with sysexits.h conventions where possible)
 # Fall back to canonical numeric equivalents when running on platforms
 # that do not expose the EX_* constants (e.g., Windows).
 EXIT_SUCCESS = EXIT_CODE_OK
 EXIT_USAGE_ERROR = EXIT_CODE_USAGE
 EXIT_NETWORK_ERROR = EXIT_CODE_TEMPFAIL
 EXIT_FATAL_ERROR = EXIT_CODE_SOFTWARE
+EXIT_SLO_VIOLATION = EXIT_CODE_SLO_VIOLATION
 
 
 # Global console for error messages
@@ -149,6 +159,7 @@ Examples:
 
 Exit codes:
   {EXIT_SUCCESS:>3} (EX_OK)       : Success
+  {EXIT_SLO_VIOLATION:>3}              : SLO threshold violation (request succeeded but too slow)
   {EXIT_USAGE_ERROR:>3} (EX_USAGE)    : Invalid arguments
   {EXIT_FATAL_ERROR:>3} (EX_SOFTWARE) : Internal error
   {EXIT_NETWORK_ERROR:>3} (EX_TEMPFAIL) : Network/TLS error (partial output available)
@@ -265,6 +276,17 @@ Exit codes:
         metavar="PATH",
         help="Export the collected metrics, network, and response details to PATH.",
     )
+    slo_keys_hint = ", ".join(sorted(SLO_KEYS))
+    output_group.add_argument(
+        "--slo",
+        metavar="KEY=MS[,KEY=MS...]",
+        default=None,
+        help=(
+            "Check the final successful step against per-phase latency budgets "
+            "in milliseconds. On violation httptap still prints the full report "
+            f"but exits with code {EXIT_SLO_VIOLATION}. Valid keys: {slo_keys_hint}."
+        ),
+    )
 
     return parser
 
@@ -314,17 +336,51 @@ def _export_results(
     renderer: OutputRenderer,
     steps: list[StepMetrics],
     args: argparse.Namespace,
+    *,
+    slo_result: SLOResult | None = None,
 ) -> None:
     """Export analysis results when --json is provided."""
     if not args.json:
         return
 
     try:
-        renderer.export_json(steps, args.url, args.json)
+        renderer.export_json(steps, args.url, args.json, slo_result=slo_result)
     except OSError as export_error:
         console.print(
             f"[yellow]⚠ Warning:[/yellow] Failed to export JSON: {export_error}",
         )
+
+
+def _evaluate_slo(
+    steps: list[StepMetrics],
+    thresholds: Mapping[str, float],
+) -> SLOResult | None:
+    """Evaluate SLO thresholds against the final successful step.
+
+    Args:
+        steps: Analysis steps.
+        thresholds: Parsed ``--slo`` specification produced by
+            :func:`parse_slo_spec`. An empty mapping disables
+            evaluation.
+
+    Returns:
+        :class:`SLOResult` when thresholds were supplied and there is
+        at least one successful step to evaluate; ``None`` otherwise.
+
+    Raises:
+        SLOSpecError: Propagated from :func:`evaluate_slo` if
+            ``thresholds`` contains a key outside :data:`SLO_KEYS`.
+            The CLI pipeline validates input via
+            :func:`parse_slo_spec` earlier, so this should not happen
+            in practice.
+
+    """
+    if not thresholds:
+        return None
+    step = select_step_for_evaluation(steps)
+    if step is None:
+        return None
+    return evaluate_slo(step, thresholds)
 
 
 def validate_arguments(args: argparse.Namespace) -> bool:
@@ -402,14 +458,45 @@ def validate_arguments(args: argparse.Namespace) -> bool:
             return False
         args.ca_bundle = str(Path(ca_bundle_str).expanduser().absolute())
 
+    if args.slo is None:
+        args.slo_thresholds = {}
+    else:
+        try:
+            args.slo_thresholds = parse_slo_spec(args.slo)
+        except SLOSpecError as exc:
+            console.print(
+                Panel(
+                    f"[red]{exc}[/red]",
+                    title="[bold red]❌ SLO Error[/bold red]",
+                    border_style="red",
+                    padding=(1, 2),
+                )
+            )
+            return False
+
     return True
 
 
-def determine_exit_code(steps: list[StepMetrics]) -> int:
+def determine_exit_code(
+    steps: list[StepMetrics],
+    *,
+    slo_result: SLOResult | None = None,
+) -> int:
     """Determine appropriate exit code based on analysis results.
+
+    Precedence (highest-severity first):
+
+    1. No steps at all → ``EXIT_FATAL_ERROR``.
+    2. Network / TLS error → ``EXIT_NETWORK_ERROR`` (or
+       ``EXIT_FATAL_ERROR`` when there is also no partial data).
+    3. SLO violation on the final successful step →
+       ``EXIT_SLO_VIOLATION``.
+    4. Otherwise → ``EXIT_SUCCESS``.
 
     Args:
         steps: List of step metrics from analysis.
+        slo_result: Optional SLO evaluation result for the final
+            successful step.
 
     Returns:
         Appropriate exit code.
@@ -419,20 +506,24 @@ def determine_exit_code(steps: list[StepMetrics]) -> int:
         return EXIT_FATAL_ERROR
 
     has_errors = any(step.has_error for step in steps)
-    if not has_errors:
-        return EXIT_SUCCESS
+    if has_errors:
+        # Check if we have any partial data (network or response info)
+        has_partial_data = any(step.network.ip or step.response.status for step in steps)
+        return EXIT_NETWORK_ERROR if has_partial_data else EXIT_FATAL_ERROR
 
-    # Check if we have any partial data (network or response info)
-    has_partial_data = any(step.network.ip or step.response.status for step in steps)
+    if slo_result is not None and not slo_result.passed:
+        return EXIT_SLO_VIOLATION
 
-    return EXIT_NETWORK_ERROR if has_partial_data else EXIT_FATAL_ERROR
+    return EXIT_SUCCESS
 
 
 def main() -> int:
     """Run the CLI with Rich UI enhancements.
 
     Returns:
-        Exit code (0=success, 64=bad args, 75=network issue, 70=internal error).
+        Exit code: ``0`` on success, ``4`` on SLO threshold violation,
+        ``64`` on invalid arguments, ``70`` on internal error, and
+        ``75`` on network or TLS failure.
 
     """
     try:
@@ -485,10 +576,11 @@ def main() -> int:
         )
 
         steps = _execute_analysis(analyzer, args, method, content, headers_dict)
-        renderer.render_analysis(steps, args.url)
-        _export_results(renderer, steps, args)
+        slo_result = _evaluate_slo(steps, args.slo_thresholds)
+        renderer.render_analysis(steps, args.url, slo_result=slo_result)
+        _export_results(renderer, steps, args, slo_result=slo_result)
 
-        return determine_exit_code(steps)
+        return determine_exit_code(steps, slo_result=slo_result)
 
     except KeyboardInterrupt:
         console.print("\n[yellow]⚠ Interrupted by user[/yellow]")

--- a/httptap/constants.py
+++ b/httptap/constants.py
@@ -36,6 +36,9 @@ CERT_EXPIRY_WARNING_DAYS = 90
 UNIX_SIGNAL_EXIT_OFFSET = 128
 BYTES_PER_KIB = 1024
 
+# Exit codes aligned with sysexits.h. Sourced from ``os`` when available
+# (POSIX platforms) with canonical numeric fallbacks for environments
+# that do not expose ``os.EX_*`` constants (notably Windows).
 _EX_OK_FALLBACK = 0
 _EX_USAGE_FALLBACK = 64
 _EX_TEMPFAIL_FALLBACK = 75
@@ -45,6 +48,11 @@ EXIT_CODE_OK = getattr(os, "EX_OK", _EX_OK_FALLBACK)
 EXIT_CODE_USAGE = getattr(os, "EX_USAGE", _EX_USAGE_FALLBACK)
 EXIT_CODE_TEMPFAIL = getattr(os, "EX_TEMPFAIL", _EX_TEMPFAIL_FALLBACK)
 EXIT_CODE_SOFTWARE = getattr(os, "EX_SOFTWARE", _EX_SOFTWARE_FALLBACK)
+
+# Project-specific exit codes (no sysexits.h equivalent).
+# SLO threshold violation — chosen to match the de-facto convention
+# established by httpstat so the same CI gate works for both tools.
+EXIT_CODE_SLO_VIOLATION = 4
 
 HTTP_SUCCESS_MIN = HTTPStatus.OK.value
 HTTP_SUCCESS_MAX = HTTPStatus.MULTIPLE_CHOICES.value - 1

--- a/httptap/exporter.py
+++ b/httptap/exporter.py
@@ -13,9 +13,10 @@ from rich.console import Console
 
 from .interfaces import Exporter
 from .models import StepMetrics
+from .slo import SLOResult
 
 
-class SummaryExport(TypedDict):
+class SummaryExport(TypedDict, total=False):
     """Summary statistics included with exported analysis."""
 
     total_time_ms: float
@@ -23,6 +24,7 @@ class SummaryExport(TypedDict):
     final_url: str
     final_bytes: int
     errors: int
+    slo: dict[str, Any]
 
 
 class ExportPayload(TypedDict):
@@ -61,6 +63,8 @@ class JSONExporter(Exporter):
         steps: Sequence[StepMetrics],
         initial_url: str,
         output_path: str,
+        *,
+        slo_result: SLOResult | None = None,
     ) -> None:
         """Export analysis data to JSON file.
 
@@ -71,12 +75,14 @@ class JSONExporter(Exporter):
             steps: Sequence of step metrics to export.
             initial_url: Initial URL that was analyzed.
             output_path: Path to output JSON file.
+            slo_result: Optional SLO evaluation result to embed under
+                ``summary.slo``.
 
         Raises:
             IOError: If file cannot be written.
 
         """
-        data = self._build_export_data(steps, initial_url)
+        data = self._build_export_data(steps, initial_url, slo_result=slo_result)
         self._write_json_file(data, output_path)
         self._print_success(output_path)
 
@@ -84,12 +90,15 @@ class JSONExporter(Exporter):
         self,
         steps: Sequence[StepMetrics],
         initial_url: str,
+        *,
+        slo_result: SLOResult | None = None,
     ) -> ExportPayload:
         """Build export data structure.
 
         Args:
             steps: Sequence of step metrics.
             initial_url: Initial URL.
+            slo_result: Optional SLO evaluation result.
 
         Returns:
             Dictionary ready for JSON serialization.
@@ -99,19 +108,23 @@ class JSONExporter(Exporter):
             "initial_url": initial_url,
             "total_steps": len(steps),
             "steps": [step.to_dict() for step in steps],
-            "summary": self._build_summary(steps, initial_url),
+            "summary": self._build_summary(steps, initial_url, slo_result=slo_result),
         }
 
     @staticmethod
     def _build_summary(
         steps: Sequence[StepMetrics],
         initial_url: str,
+        *,
+        slo_result: SLOResult | None = None,
     ) -> SummaryExport:
         """Build summary section of export data.
 
         Args:
             steps: Sequence of step metrics.
             initial_url: Initial URL.
+            slo_result: Optional SLO evaluation result to attach under
+                the ``slo`` key.
 
         Returns:
             Summary dictionary.
@@ -119,13 +132,16 @@ class JSONExporter(Exporter):
         """
         successful_steps = [s for s in steps if not s.has_error]
 
-        return {
+        summary: SummaryExport = {
             "total_time_ms": sum(s.timing.total_ms for s in successful_steps),
             "final_status": (steps[-1].response.status if steps and not steps[-1].has_error else None),
             "final_url": steps[-1].url if steps else initial_url,
             "final_bytes": (steps[-1].response.bytes if steps and not steps[-1].has_error else 0),
             "errors": sum(1 for s in steps if s.has_error),
         }
+        if slo_result is not None:
+            summary["slo"] = slo_result.to_dict()
+        return summary
 
     @staticmethod
     def _write_json_file(data: ExportPayload, output_path: str) -> None:

--- a/httptap/formatters.py
+++ b/httptap/formatters.py
@@ -21,6 +21,7 @@ from .constants import (
     PROXY_SOURCE_NO_PROXY,
 )
 from .models import StepMetrics
+from .slo import SLOResult
 
 
 def format_step_header(step: StepMetrics) -> str:
@@ -195,18 +196,27 @@ def format_bytes_human(num_bytes: int) -> str:
     return f"{size_kib / BYTES_PER_KIB:.1f} MB"
 
 
-def format_metrics_line(step: StepMetrics) -> str:
+def format_metrics_line(
+    step: StepMetrics,
+    *,
+    slo_result: SLOResult | None = None,
+) -> str:
     """Format step metrics as machine-readable line.
 
     Args:
         step: Step metrics to format.
+        slo_result: Evaluated SLO result. When provided, appends
+            ``slo=pass`` or ``slo=fail slo_violations=<keys>`` to the
+            output so downstream tooling can branch on a single line.
 
     Returns:
         Space-separated key=value pairs.
 
     Examples:
         >>> format_metrics_line(step)
-        'dns=1.5 connect=45.2 tls=67.8 ttfb=156.4 total=234.7 status=200 bytes=1256'
+        'Step 1: dns=1.5 ... total=234.7 status=200 bytes=1256 proxy=direct'
+        >>> format_metrics_line(step, slo_result)
+        'Step 1: ... proxy=direct slo=fail slo_violations=total,ttfb'
 
     """
     parts = [
@@ -238,6 +248,14 @@ def format_metrics_line(step: StepMetrics) -> str:
         parts.append("proxy=direct proxy_from=no_scheme_match")
     else:
         parts.append("proxy=direct")
+
+    if slo_result is not None:
+        if slo_result.passed:
+            parts.append("slo=pass")
+        else:
+            violated = ",".join(v.key for v in slo_result.violations)
+            parts.append("slo=fail")
+            parts.append(f"slo_violations={violated}")
 
     return f"Step {step.step_number}: {' '.join(parts)}"
 
@@ -279,3 +297,43 @@ def format_compact_line(step: StepMetrics) -> str:
     size = format_bytes_human(step.response.bytes)
 
     return f"Step {step.step_number}: {status} {method} {step.url} | {timings} | {size}"
+
+
+def format_slo_panel(result: SLOResult) -> Panel:
+    """Render SLO thresholds and any violations as a Rich panel.
+
+    Args:
+        result: Evaluated SLO result.
+
+    Returns:
+        A Rich ``Panel`` suitable for printing after the waterfall.
+
+    """
+    title = "[bold green]✓ SLO: pass[/bold green]" if result.passed else "[bold red]✗ SLO: fail[/bold red]"
+    border = "green" if result.passed else "red"
+
+    body = Text()
+    body.append("Thresholds: ", style="bold")
+    if result.thresholds_ms:
+        parts = [f"{key}≤{value:g}ms" for key, value in sorted(result.thresholds_ms.items())]
+        body.append(", ".join(parts))
+    else:
+        body.append("(none)", style="dim")
+
+    if not result.passed:
+        body.append("\n")
+        body.append("Violations:\n", style="bold red")
+        for violation in result.violations:
+            body.append(
+                f"  • {violation.key}: "
+                f"{violation.actual_ms:.1f}ms > {violation.threshold_ms:g}ms "
+                f"(+{violation.delta_ms:.1f}ms)\n",
+                style="red",
+            )
+
+    return Panel(
+        body,
+        title=title,
+        border_style=border,
+        padding=(0, 1),
+    )

--- a/httptap/interfaces.py
+++ b/httptap/interfaces.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from .models import NetworkInfo, StepMetrics, TimingMetrics
+    from .slo import SLOResult
 
 
 class Visualizer(Protocol):
@@ -77,6 +78,8 @@ class Exporter(Protocol):
         steps: Sequence[StepMetrics],
         initial_url: str,
         output_path: str,
+        *,
+        slo_result: SLOResult | None = None,
     ) -> None:
         """Persist the collected steps using the chosen representation.
 
@@ -84,6 +87,8 @@ class Exporter(Protocol):
             steps: Sequence of step metrics to export.
             initial_url: The initial URL that was analyzed.
             output_path: Path to output file where results should be written.
+            slo_result: Optional SLO evaluation result that concrete
+                exporters may embed alongside the step data.
 
         Raises:
             IOError: If file cannot be written or path is invalid.

--- a/httptap/render.py
+++ b/httptap/render.py
@@ -25,10 +25,12 @@ from .formatters import (
     format_metrics_line,
     format_network_info,
     format_response_info,
+    format_slo_panel,
     format_step_header,
 )
 from .interfaces import Exporter, Visualizer
 from .models import StepMetrics
+from .slo import SLOResult, select_step_for_evaluation
 from .visualizer import WaterfallVisualizer
 
 
@@ -76,7 +78,13 @@ class OutputRenderer:
         self.visualizer = visualizer or WaterfallVisualizer(self.console)
         self.exporter = exporter or JSONExporter(self.console)
 
-    def render_analysis(self, steps: Sequence[StepMetrics], initial_url: str) -> None:
+    def render_analysis(
+        self,
+        steps: Sequence[StepMetrics],
+        initial_url: str,
+        *,
+        slo_result: SLOResult | None = None,
+    ) -> None:
         """Render complete analysis output.
 
         Selects the output shape based on the flags the renderer was
@@ -92,14 +100,19 @@ class OutputRenderer:
         Args:
             steps: Sequence of step metrics to render.
             initial_url: Initial URL that was analyzed.
+            slo_result: Optional SLO evaluation result. When provided,
+                the result is rendered alongside the step output
+                (inline in metrics-only mode, as a Rich panel
+                otherwise).
 
         """
         if self.metrics_only:
-            self._render_metrics_only(steps)
+            self._render_metrics_only(steps, slo_result=slo_result)
             return
 
         if self.compact:
             self._render_compact(steps, initial_url)
+            self._print_slo_panel(slo_result)
             return
 
         self._print_header(initial_url)
@@ -112,6 +125,15 @@ class OutputRenderer:
 
         if len(steps) > 1:
             self._render_redirect_summary(steps)
+
+        self._print_slo_panel(slo_result)
+
+    def _print_slo_panel(self, slo_result: SLOResult | None) -> None:
+        """Print the SLO panel below the step output when SLO was evaluated."""
+        if slo_result is None:
+            return
+        self.console.print()
+        self.console.print(format_slo_panel(slo_result))
 
     def _render_compact(self, steps: Sequence[StepMetrics], initial_url: str) -> None:
         """Render one human-readable summary line per step.
@@ -137,6 +159,8 @@ class OutputRenderer:
         steps: Sequence[StepMetrics],
         initial_url: str,
         output_path: str,
+        *,
+        slo_result: SLOResult | None = None,
     ) -> None:
         """Export analysis data to JSON file.
 
@@ -144,9 +168,11 @@ class OutputRenderer:
             steps: Sequence of step metrics to export.
             initial_url: Initial URL that was analyzed.
             output_path: Path to output JSON file.
+            slo_result: Optional SLO evaluation result that will be
+                attached to the exported summary.
 
         """
-        self.exporter.export(steps, initial_url, output_path)
+        self.exporter.export(steps, initial_url, output_path, slo_result=slo_result)
 
     def _print_header(self, initial_url: str) -> None:
         """Print analysis header with Rich panel.
@@ -203,18 +229,33 @@ class OutputRenderer:
 
         self.visualizer.render(step)
 
-    def _render_metrics_only(self, steps: Sequence[StepMetrics]) -> None:
+    def _render_metrics_only(
+        self,
+        steps: Sequence[StepMetrics],
+        *,
+        slo_result: SLOResult | None = None,
+    ) -> None:
         """Render minimal machine-readable output.
+
+        The SLO result is attached to the **final successful step**
+        only, matching how SLOs are evaluated (against the final
+        request of the redirect chain).
 
         Args:
             steps: Sequence of step metrics.
+            slo_result: Evaluated SLO result, or ``None`` when no
+                ``--slo`` was supplied.
 
         """
+        slo_target = select_step_for_evaluation(steps) if slo_result is not None else None
+
         for step in steps:
             if step.has_error:
                 self.console.print(f"Step {step.step_number}: ERROR - {step.error}")
-            else:
-                self.console.print(format_metrics_line(step))
+                continue
+
+            step_slo = slo_result if step is slo_target else None
+            self.console.print(format_metrics_line(step, slo_result=step_slo))
 
     def _render_redirect_summary(self, steps: Sequence[StepMetrics]) -> None:
         """Render redirect chain summary table.

--- a/httptap/slo.py
+++ b/httptap/slo.py
@@ -1,0 +1,287 @@
+"""Service Level Objective (SLO) evaluation for HTTP request timings.
+
+This module implements SLO threshold checking: the user supplies
+per-phase latency budgets (in milliseconds) and httptap evaluates the
+actual measurements against them. A violation produces a non-zero
+exit code, structured violation records in the JSON export, and
+human-readable output for terminal and scripting pipelines.
+
+SLO keys map one-to-one to ``TimingMetrics`` fields that express a
+duration in milliseconds. The ``is_estimated`` flag is intentionally
+excluded because it is boolean, not a duration.
+
+Typical usage:
+    >>> thresholds = parse_slo_spec("total=500,ttfb=200")
+    >>> result = evaluate_slo(step, thresholds)
+    >>> if not result.passed:
+    ...     for v in result.violations:
+    ...         print(f"{v.key}: {v.actual_ms}ms > {v.threshold_ms}ms")
+
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from .models import StepMetrics
+
+
+# Keys accepted in ``--slo``. Each maps to a ``TimingMetrics.*_ms``
+# field; adding a new entry here requires updating the ``timing_map``
+# inside :func:`evaluate_slo` so the key-to-attribute mapping stays
+# in sync.
+SLO_KEYS: frozenset[str] = frozenset({"dns", "connect", "tls", "ttfb", "wait", "xfer", "total"})
+
+
+class SLOSpecError(ValueError):
+    """Raised when an ``--slo`` specification cannot be parsed."""
+
+
+@dataclass(frozen=True, slots=True)
+class SLOViolation:
+    """A single threshold violation.
+
+    Attributes:
+        key: Timing phase key (e.g., ``"total"``, ``"ttfb"``).
+        threshold_ms: Budget supplied by the user, in milliseconds.
+        actual_ms: Measured timing value, in milliseconds.
+
+    """
+
+    key: str
+    threshold_ms: float
+    actual_ms: float
+
+    @property
+    def delta_ms(self) -> float:
+        """Overrun over the budget, in milliseconds.
+
+        By construction :func:`evaluate_slo` only emits violations where
+        ``actual_ms > threshold_ms``, so this value is always strictly
+        positive for objects produced by this module. Callers that
+        instantiate ``SLOViolation`` directly should preserve this
+        invariant to keep downstream output consistent.
+        """
+        return self.actual_ms - self.threshold_ms
+
+    def to_dict(self) -> dict[str, float | str]:
+        """Serialize to a plain ``dict`` for JSON export.
+
+        Returns:
+            Mapping with keys ``key``, ``threshold_ms``, ``actual_ms``,
+            ``delta_ms``.
+
+        """
+        return {
+            "key": self.key,
+            "threshold_ms": self.threshold_ms,
+            "actual_ms": self.actual_ms,
+            "delta_ms": self.delta_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SLOResult:
+    """Result of evaluating timings against a set of SLO thresholds.
+
+    Produced by :func:`evaluate_slo`, which guarantees the contract
+    used by the rest of the codebase:
+
+    * ``thresholds_ms`` is a fresh ``dict`` snapshot of the input
+      mapping — safe to mutate by the caller without affecting the
+      result object's serialization.
+    * ``violations`` is a ``tuple`` sorted alphabetically by
+      :attr:`SLOViolation.key`, making :meth:`to_dict` output
+      byte-stable across evaluations with the same input.
+
+    The dataclass is ``frozen=True`` so attribute reassignment is
+    blocked; this is shallow immutability (as with any Python frozen
+    dataclass) — external callers who hand-construct ``SLOResult``
+    with mutable containers should not mutate them after handover.
+
+    :class:`SLOResult` is not hashable (``thresholds_ms`` is a
+    ``dict``) and therefore cannot be used as a ``dict`` key or added
+    to a ``set``; equality comparison via ``==`` works and is
+    structural.
+
+    Attributes:
+        thresholds_ms: User-supplied budgets keyed by SLO key.
+        violations: Violations sorted alphabetically by ``key``.
+            When empty, the evaluation passed.
+
+    """
+
+    thresholds_ms: dict[str, float] = field(default_factory=dict)
+    violations: tuple[SLOViolation, ...] = ()
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` when every threshold was met or undercut."""
+        return len(self.violations) == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain ``dict`` for JSON export.
+
+        Threshold keys are emitted in alphabetical order so that two
+        evaluations with the same user input always produce
+        byte-identical JSON (useful for diffing and cache keys).
+
+        Returns:
+            Mapping with keys ``pass``, ``thresholds_ms``, ``violations``.
+
+        """
+        return {
+            "pass": self.passed,
+            "thresholds_ms": {key: self.thresholds_ms[key] for key in sorted(self.thresholds_ms)},
+            "violations": [v.to_dict() for v in self.violations],
+        }
+
+
+def parse_slo_spec(raw: str) -> dict[str, float]:
+    """Parse an ``--slo`` specification string.
+
+    The expected grammar is a comma-separated list of ``KEY=MS`` pairs.
+    Whitespace around keys and values is tolerated. Keys are
+    case-insensitive and normalised to lowercase.
+
+    Args:
+        raw: String passed via ``--slo``, e.g. ``"total=500,ttfb=200"``.
+
+    Returns:
+        Mapping of lowercase SLO key to threshold in milliseconds.
+
+    Raises:
+        SLOSpecError: If the string is empty, a pair is malformed, a
+            key is unknown, a key is duplicated, or a value is not a
+            positive, finite number.
+
+    Examples:
+        >>> parse_slo_spec("total=500,ttfb=200")
+        {'total': 500.0, 'ttfb': 200.0}
+        >>> parse_slo_spec("Total=500")
+        {'total': 500.0}
+
+    """
+    if not raw or not raw.strip():
+        msg = "SLO specification is empty (expected KEY=MS[,KEY=MS...])."
+        raise SLOSpecError(msg)
+
+    thresholds: dict[str, float] = {}
+
+    for pair in raw.split(","):
+        token = pair.strip()
+        if not token:
+            msg = f"Empty item in SLO specification '{raw}' (expected KEY=MS[,KEY=MS...])."
+            raise SLOSpecError(msg)
+
+        if token.count("=") != 1:
+            msg = f"Invalid SLO item '{token}' (expected exactly one '=' between KEY and MS)."
+            raise SLOSpecError(msg)
+
+        key_raw, value_raw = token.split("=", 1)
+        key = key_raw.strip().lower()
+        value_str = value_raw.strip()
+
+        if not key:
+            msg = f"Invalid SLO item '{token}' (KEY must not be empty)."
+            raise SLOSpecError(msg)
+
+        if key not in SLO_KEYS:
+            allowed = ", ".join(sorted(SLO_KEYS))
+            msg = f"Unknown SLO key '{key}'. Valid keys: {allowed}."
+            raise SLOSpecError(msg)
+
+        if key in thresholds:
+            msg = f"Duplicate SLO key '{key}' in specification '{raw}'."
+            raise SLOSpecError(msg)
+
+        try:
+            value = float(value_str)
+        except ValueError as exc:
+            msg = f"Invalid SLO value for '{key}': '{value_str}' is not a number."
+            raise SLOSpecError(msg) from exc
+
+        if not math.isfinite(value) or value <= 0:
+            msg = f"Invalid SLO value for '{key}': '{value_str}' must be a positive finite number of milliseconds."
+            raise SLOSpecError(msg)
+
+        thresholds[key] = value
+
+    return thresholds
+
+
+def evaluate_slo(
+    step: StepMetrics,
+    thresholds: Mapping[str, float],
+) -> SLOResult:
+    """Evaluate timings on a single step against SLO thresholds.
+
+    Args:
+        step: Step whose ``timing`` is compared to the thresholds.
+        thresholds: Mapping of SLO key to threshold in milliseconds.
+            Every key must be a member of :data:`SLO_KEYS`.
+
+    Returns:
+        :class:`SLOResult` listing any violations in ascending
+        alphabetical order of the user-supplied threshold keys. The
+        order is stable so the JSON export is reproducible.
+
+    Raises:
+        SLOSpecError: If ``thresholds`` contains a key that is not a
+            member of :data:`SLO_KEYS`. Programmatic callers are
+            expected to validate input via :func:`parse_slo_spec`
+            first; this check guards against accidental misuse.
+
+    """
+    unknown = set(thresholds) - SLO_KEYS
+    if unknown:
+        allowed = ", ".join(sorted(SLO_KEYS))
+        bad = ", ".join(sorted(unknown))
+        msg = f"Unknown SLO key(s): {bad}. Valid keys: {allowed}."
+        raise SLOSpecError(msg)
+
+    # Keep this mapping in lockstep with SLO_KEYS (the frozenset above).
+    timing_map: dict[str, float] = {
+        "dns": step.timing.dns_ms,
+        "connect": step.timing.connect_ms,
+        "tls": step.timing.tls_ms,
+        "ttfb": step.timing.ttfb_ms,
+        "wait": step.timing.wait_ms,
+        "xfer": step.timing.xfer_ms,
+        "total": step.timing.total_ms,
+    }
+
+    violations = tuple(
+        SLOViolation(key=key, threshold_ms=thresholds[key], actual_ms=timing_map[key])
+        for key in sorted(thresholds)
+        if timing_map[key] > thresholds[key]
+    )
+
+    return SLOResult(thresholds_ms=dict(thresholds), violations=violations)
+
+
+def select_step_for_evaluation(steps: Sequence[StepMetrics]) -> StepMetrics | None:
+    """Pick the step whose timing should be checked against SLO.
+
+    By convention, SLOs apply to the *final* successful step of a
+    redirect chain (the one that actually served the user's request).
+    If every step errored out, returns ``None`` — the caller is
+    expected to treat that as a network failure rather than an SLO
+    violation.
+
+    Args:
+        steps: Steps returned by ``HTTPTapAnalyzer.analyze_url``.
+
+    Returns:
+        Final successful step, or ``None`` if there is no such step.
+
+    """
+    for step in reversed(steps):
+        if not step.has_error:
+            return step
+    return None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
   - Usage:
       - Basic Usage: usage/basic.md
       - Output Formats: usage/output-formats.md
+      - SLO Threshold Checking: usage/slo.md
       - Advanced Features: usage/advanced.md
       - Troubleshooting & FAQ: troubleshooting.md
   - Security:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ else:
 from httptap.cli import (
     EXIT_FATAL_ERROR,
     EXIT_NETWORK_ERROR,
+    EXIT_SLO_VIOLATION,
     EXIT_SUCCESS,
     EXIT_USAGE_ERROR,
     _export_results,
@@ -28,6 +29,7 @@ from httptap.cli import (
 )
 from httptap.constants import UNIX_SIGNAL_EXIT_OFFSET, HTTPMethod
 from httptap.models import NetworkInfo, ResponseInfo, StepMetrics, TimingMetrics
+from httptap.slo import SLOResult, SLOViolation
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -124,7 +126,13 @@ class RendererStub:
     def __init__(self) -> None:
         self.rendered: list[tuple[list[StepMetrics], str]] = []
 
-    def render_analysis(self, steps: list[StepMetrics], initial_url: str) -> None:
+    def render_analysis(
+        self,
+        steps: list[StepMetrics],
+        initial_url: str,
+        slo_result: object | None = None,
+    ) -> None:
+        del slo_result
         self.rendered.append((steps, initial_url))
 
     def export_json(
@@ -132,8 +140,10 @@ class RendererStub:
         _steps: list[StepMetrics],
         _initial_url: str,
         _path: str,
+        *,
+        slo_result: object | None = None,
     ) -> None:
-        return None
+        del slo_result
 
 
 def test_main_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -287,6 +297,7 @@ def test_validate_arguments_cacert_valid_path(tmp_path: Path) -> None:
         json=None,
         ignore_ssl=False,
         ca_bundle=str(ca_bundle),
+        slo=None,
     )
     result = validate_arguments(args)
 
@@ -305,6 +316,7 @@ def test_validate_arguments_cacert_empty_string(
         json=None,
         ignore_ssl=False,
         ca_bundle="   ",  # Empty/whitespace only
+        slo=None,
     )
 
     result = validate_arguments(args)
@@ -323,6 +335,7 @@ def test_validate_arguments_cacert_expanduser() -> None:
         json=None,
         ignore_ssl=False,
         ca_bundle="~/ca-bundle.pem",
+        slo=None,
     )
     result = validate_arguments(args)
 
@@ -688,3 +701,238 @@ def test_no_auto_post_when_method_explicitly_specified(
     # Verify WARNING log about uncommon usage
     captured_output = capsys.readouterr()
     # Note: logger.warning goes to stderr, not stdout
+
+
+# ---------------------------------------------------------------------------
+# SLO integration tests
+# ---------------------------------------------------------------------------
+
+
+class _SLOAnalyzerStub:
+    """Minimal analyzer that returns one step with caller-specified timing."""
+
+    def __init__(self, total_ms: float, *, error: str | None = None) -> None:
+        self._total_ms = total_ms
+        self._error = error
+
+    def analyze_url(
+        self,
+        url: str,
+        *,
+        method: HTTPMethod = HTTPMethod.GET,
+        content: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> list[StepMetrics]:
+        del method, content, headers
+        timing = TimingMetrics(
+            dns_ms=5.0,
+            connect_ms=10.0,
+            tls_ms=20.0,
+            ttfb_ms=50.0,
+            total_ms=self._total_ms,
+        )
+        timing.calculate_derived()
+        network = NetworkInfo(ip="203.0.113.1", ip_family="IPv4")
+        response = ResponseInfo(status=200, bytes=128)
+        return [
+            StepMetrics(
+                url=url,
+                step_number=1,
+                timing=timing,
+                network=network,
+                response=response,
+                error=self._error,
+            )
+        ]
+
+
+def _install_slo_analyzer_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    analyzer: _SLOAnalyzerStub,
+) -> None:
+    monkeypatch.setattr(
+        "httptap.cli.HTTPTapAnalyzer",
+        lambda *_args, **_kwargs: analyzer,
+    )
+
+
+def test_main_slo_pass_returns_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=120.0))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["httptap", "--metrics-only", "--slo", "total=500", "https://example.test"],
+    )
+
+    exit_code = main()
+    stdout = capsys.readouterr().out
+
+    assert exit_code == EXIT_SUCCESS
+    assert "slo=pass" in stdout
+    assert "slo=fail" not in stdout
+
+
+def test_main_slo_fail_returns_slo_violation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=900.0))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["httptap", "--metrics-only", "--slo", "total=500", "https://example.test"],
+    )
+
+    exit_code = main()
+    stdout = capsys.readouterr().out
+
+    assert exit_code == EXIT_SLO_VIOLATION
+    assert "slo=fail" in stdout
+    assert "slo_violations=total" in stdout
+
+
+def test_main_slo_multiple_violations_are_comma_joined(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=900.0))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "httptap",
+            "--metrics-only",
+            "--slo",
+            "total=500,ttfb=10",
+            "https://example.test",
+        ],
+    )
+
+    exit_code = main()
+    stdout = capsys.readouterr().out
+
+    assert exit_code == EXIT_SLO_VIOLATION
+    # Violations sorted alphabetically.
+    assert "slo_violations=total,ttfb" in stdout
+
+
+def test_main_slo_invalid_spec_returns_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=100.0))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["httptap", "--slo", "bogus", "https://example.test"],
+    )
+
+    exit_code = main()
+    stderr = capsys.readouterr().err
+
+    assert exit_code == EXIT_USAGE_ERROR
+    assert "SLO Error" in stderr
+
+
+def test_main_slo_network_error_beats_slo_violation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network failure takes precedence over an SLO failure."""
+    analyzer = _SLOAnalyzerStub(total_ms=900.0, error="connection refused")
+    _install_slo_analyzer_stub(monkeypatch, analyzer)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["httptap", "--slo", "total=500", "https://example.test"],
+    )
+
+    exit_code = main()
+
+    assert exit_code == EXIT_NETWORK_ERROR
+
+
+def test_main_slo_json_export_contains_slo_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=900.0))
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "httptap",
+            "--metrics-only",
+            "--slo",
+            "total=500",
+            "--json",
+            str(output_path),
+            "https://example.test",
+        ],
+    )
+
+    exit_code = main()
+
+    assert exit_code == EXIT_SLO_VIOLATION
+    payload = json.loads(output_path.read_text())
+    slo_block = payload["summary"]["slo"]
+    assert slo_block["pass"] is False
+    assert slo_block["thresholds_ms"] == {"total": 500.0}
+    assert slo_block["violations"] == [
+        {
+            "key": "total",
+            "threshold_ms": 500.0,
+            "actual_ms": 900.0,
+            "delta_ms": 400.0,
+        }
+    ]
+
+
+def test_main_without_slo_flag_has_no_slo_in_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_slo_analyzer_stub(monkeypatch, _SLOAnalyzerStub(total_ms=100.0))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["httptap", "--metrics-only", "https://example.test"],
+    )
+
+    exit_code = main()
+    stdout = capsys.readouterr().out
+
+    assert exit_code == EXIT_SUCCESS
+    assert "slo=" not in stdout
+
+
+def test_determine_exit_code_slo_pass_returns_success() -> None:
+    step = StepMetrics(
+        url="https://example.test",
+        timing=TimingMetrics(total_ms=100.0),
+        network=NetworkInfo(ip="203.0.113.1"),
+        response=ResponseInfo(status=200),
+    )
+    result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+    assert determine_exit_code([step], slo_result=result) == EXIT_SUCCESS
+
+
+def test_determine_exit_code_slo_fail_returns_slo_violation() -> None:
+    step = StepMetrics(
+        url="https://example.test",
+        timing=TimingMetrics(total_ms=900.0),
+        network=NetworkInfo(ip="203.0.113.1"),
+        response=ResponseInfo(status=200),
+    )
+    violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=900.0)
+    result = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+    assert determine_exit_code([step], slo_result=result) == EXIT_SLO_VIOLATION
+
+
+def test_determine_exit_code_network_error_overrides_slo() -> None:
+    step = StepMetrics(
+        url="https://example.test",
+        timing=TimingMetrics(total_ms=900.0),
+        network=NetworkInfo(ip="203.0.113.1"),
+        response=ResponseInfo(status=None),
+        error="connection refused",
+    )
+    violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=900.0)
+    result = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+    assert determine_exit_code([step], slo_result=result) == EXIT_NETWORK_ERROR

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 from httptap.exporter import JSONExporter
 from httptap.models import NetworkInfo, ResponseInfo, StepMetrics, TimingMetrics
+from httptap.slo import SLOResult, SLOViolation
 
 PathType = pathlib.Path
 
@@ -127,3 +128,66 @@ def test_exporter_with_empty_request_headers(tmp_path: PathType) -> None:
     assert data["steps"][0]["request"]["headers"] == {}
     assert data["steps"][0]["request"]["method"] == "GET"
     assert data["steps"][0]["request"]["body_bytes"] == 0
+
+
+def test_exporter_omits_slo_when_not_provided(tmp_path: PathType) -> None:
+    """The ``slo`` key is absent from the summary unless explicitly set."""
+    exporter = JSONExporter(Console(record=True))
+    step = build_step("https://example.test", 200, 100.0)
+    output_path = tmp_path / "no-slo.json"
+
+    exporter.export([step], "https://example.test", str(output_path))
+
+    data = json.loads(output_path.read_text())
+    assert "slo" not in data["summary"]
+
+
+def test_exporter_includes_slo_pass(tmp_path: PathType) -> None:
+    """A passing SLO is embedded as ``summary.slo`` with an empty violations list."""
+    exporter = JSONExporter(Console(record=True))
+    step = build_step("https://example.test", 200, 100.0)
+    result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+    output_path = tmp_path / "slo-pass.json"
+
+    exporter.export(
+        [step],
+        "https://example.test",
+        str(output_path),
+        slo_result=result,
+    )
+
+    data = json.loads(output_path.read_text())
+    assert data["summary"]["slo"] == {
+        "pass": True,
+        "thresholds_ms": {"total": 500.0},
+        "violations": [],
+    }
+
+
+def test_exporter_includes_slo_fail(tmp_path: PathType) -> None:
+    """A failing SLO lists violations with ``key``, thresholds, actual, delta."""
+    exporter = JSONExporter(Console(record=True))
+    step = build_step("https://example.test", 200, 900.0)
+    violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=900.0)
+    result = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+    output_path = tmp_path / "slo-fail.json"
+
+    exporter.export(
+        [step],
+        "https://example.test",
+        str(output_path),
+        slo_result=result,
+    )
+
+    data = json.loads(output_path.read_text())
+    slo = data["summary"]["slo"]
+    assert slo["pass"] is False
+    assert slo["thresholds_ms"] == {"total": 500.0}
+    assert slo["violations"] == [
+        {
+            "key": "total",
+            "threshold_ms": 500.0,
+            "actual_ms": 900.0,
+            "delta_ms": 400.0,
+        }
+    ]

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -17,9 +17,11 @@ from httptap.formatters import (
     format_metrics_line,
     format_network_info,
     format_response_info,
+    format_slo_panel,
     format_step_header,
 )
 from httptap.models import NetworkInfo, ResponseInfo, StepMetrics, TimingMetrics
+from httptap.slo import SLOResult, SLOViolation
 
 
 def build_step(status: int) -> StepMetrics:
@@ -507,6 +509,41 @@ class TestFormatMetricsLine:
         assert "proxy=direct" in line
         assert "proxy_from" not in line
 
+    def test_format_metrics_line_slo_pass(self) -> None:
+        """A passing SLO appends ``slo=pass`` without a violations list."""
+        step = StepMetrics(step_number=1, response=ResponseInfo(status=200))
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+
+        line = format_metrics_line(step, slo_result=result)
+
+        assert line.endswith("slo=pass")
+        assert "slo_violations" not in line
+
+    def test_format_metrics_line_slo_fail(self) -> None:
+        """A failing SLO appends ``slo=fail`` and violations list."""
+        step = StepMetrics(step_number=1, response=ResponseInfo(status=200))
+        violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=900.0)
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+
+        line = format_metrics_line(step, slo_result=result)
+
+        assert "slo=fail" in line
+        assert "slo_violations=total" in line
+
+    def test_format_metrics_line_slo_multiple_violations(self) -> None:
+        """Multiple violations are joined by commas in stable order."""
+        step = StepMetrics(step_number=1, response=ResponseInfo(status=200))
+        violations = (
+            SLOViolation(key="connect", threshold_ms=100.0, actual_ms=150.0),
+            SLOViolation(key="total", threshold_ms=500.0, actual_ms=900.0),
+            SLOViolation(key="ttfb", threshold_ms=200.0, actual_ms=300.0),
+        )
+        result = SLOResult(thresholds_ms={}, violations=violations)
+
+        line = format_metrics_line(step, slo_result=result)
+
+        assert "slo_violations=connect,total,ttfb" in line
+
 
 class TestFormatCompactLine:
     """Human-readable single-line output for ``--compact``."""
@@ -546,7 +583,6 @@ class TestFormatCompactLine:
 
     def test_renders_human_readable_size(self) -> None:
         line = format_compact_line(self._make_step(bytes_=2048))
-        # 2048 B == 2.0 KB via format_bytes_human
         assert line.endswith("2.0 KB")
 
     def test_small_size_shows_bytes(self) -> None:
@@ -571,3 +607,49 @@ class TestFormatCompactLine:
     def test_single_line_no_newlines(self) -> None:
         line = format_compact_line(self._make_step())
         assert "\n" not in line
+
+
+class TestFormatSLOPanel:
+    """``format_slo_panel`` produces a Rich panel matching the SLO status."""
+
+    @staticmethod
+    def _panel_text(result: SLOResult) -> str:
+        from rich.console import Console
+
+        console = Console(record=True, width=120)
+        console.print(format_slo_panel(result))
+        return console.export_text()
+
+    def test_pass_panel_shows_thresholds(self) -> None:
+        result = SLOResult(
+            thresholds_ms={"total": 500.0, "ttfb": 200.0},
+            violations=(),
+        )
+        text = self._panel_text(result)
+
+        assert "SLO: pass" in text
+        assert "total≤500ms" in text
+        assert "ttfb≤200ms" in text
+        assert "Violations" not in text
+
+    def test_fail_panel_lists_violations(self) -> None:
+        violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=723.4)
+        result = SLOResult(
+            thresholds_ms={"total": 500.0},
+            violations=(violation,),
+        )
+        text = self._panel_text(result)
+
+        assert "SLO: fail" in text
+        assert "Violations" in text
+        assert "total" in text
+        assert "723.4" in text
+        assert "500" in text
+        assert "+223.4" in text
+
+    def test_panel_with_no_thresholds_shows_placeholder(self) -> None:
+        result = SLOResult(thresholds_ms={}, violations=())
+        text = self._panel_text(result)
+
+        assert "SLO: pass" in text
+        assert "(none)" in text

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from httptap.models import NetworkInfo, ResponseInfo, StepMetrics, TimingMetrics
 from httptap.render import OutputRenderer
+from httptap.slo import SLOResult, SLOViolation
 from httptap.visualizer import WaterfallVisualizer
 
 if TYPE_CHECKING:
@@ -195,6 +196,7 @@ class TestOutputRenderer:
             [step],
             "https://example.com",
             str(output_path),
+            slo_result=None,
         )
 
     def test_print_header(self) -> None:
@@ -220,6 +222,61 @@ class TestOutputRenderer:
         output = console.export_text()
         assert "ERROR" in output
         assert "DNS failed" in output
+
+    def test_render_metrics_only_attaches_slo_to_final_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SLO is printed only on the last successful step of a chain.
+
+        Capturing ``console.print`` directly avoids flakiness from
+        Rich's terminal-width-dependent line wrapping.
+        """
+        console = Console()
+        renderer = OutputRenderer(metrics_only=True, console=console)
+        steps = [
+            build_step("http://example.com", 301, 50.0, step_number=1),
+            build_step("https://example.com", 200, 120.0, step_number=2),
+        ]
+        violation = SLOViolation(key="total", threshold_ms=100.0, actual_ms=120.0)
+        result = SLOResult(thresholds_ms={"total": 100.0}, violations=(violation,))
+
+        printed: list[str] = []
+        monkeypatch.setattr(console, "print", lambda msg: printed.append(str(msg)))
+
+        renderer._render_metrics_only(steps, slo_result=result)
+
+        step1_line = next(line for line in printed if line.startswith("Step 1"))
+        step2_line = next(line for line in printed if line.startswith("Step 2"))
+        assert "slo=" not in step1_line
+        assert "slo=fail" in step2_line
+        assert "slo_violations=total" in step2_line
+
+    def test_render_metrics_only_skips_slo_when_all_failed(self) -> None:
+        """SLO output is suppressed when every step errored out."""
+        console = Console(record=True, width=120)
+        renderer = OutputRenderer(metrics_only=True, console=console)
+        step = build_step("https://example.com", 0, 0.0, error="DNS failed")
+        result = SLOResult(thresholds_ms={"total": 100.0}, violations=())
+
+        renderer._render_metrics_only([step], slo_result=result)
+
+        output = console.export_text()
+        assert "slo=" not in output
+
+    def test_render_analysis_prints_slo_panel(self) -> None:
+        """Non-metrics mode renders an SLO panel after the waterfall."""
+        console = Console(record=True, width=120)
+        renderer = OutputRenderer(console=console)
+        step = build_step("https://example.com", 200, 120.0)
+        violation = SLOViolation(key="total", threshold_ms=100.0, actual_ms=120.0)
+        result = SLOResult(thresholds_ms={"total": 100.0}, violations=(violation,))
+
+        renderer.render_analysis([step], "https://example.com", slo_result=result)
+
+        output = console.export_text()
+        assert "SLO: fail" in output
+        assert "total" in output
 
     def test_build_redirect_table_structure(self) -> None:
         """Test redirect table structure."""

--- a/tests/test_slo.py
+++ b/tests/test_slo.py
@@ -1,0 +1,313 @@
+"""Tests for the SLO threshold evaluation module."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from httptap.models import StepMetrics, TimingMetrics
+from httptap.slo import (
+    SLO_KEYS,
+    SLOResult,
+    SLOSpecError,
+    SLOViolation,
+    evaluate_slo,
+    parse_slo_spec,
+    select_step_for_evaluation,
+)
+
+
+def _step(
+    *,
+    step_number: int = 1,
+    error: str | None = None,
+    **timing_fields: float,
+) -> StepMetrics:
+    """Build a minimal ``StepMetrics`` for SLO tests.
+
+    Any ``<key>_ms`` keyword argument is forwarded to
+    :class:`TimingMetrics`; unknown keys raise ``TypeError`` from the
+    dataclass constructor.
+
+    """
+    return StepMetrics(
+        url="https://example.com",
+        step_number=step_number,
+        timing=TimingMetrics(**timing_fields),  # type: ignore[arg-type]
+        error=error,
+    )
+
+
+class TestSLOKeys:
+    """SLO_KEYS should cover every duration-valued TimingMetrics field."""
+
+    def test_expected_keys_are_present(self) -> None:
+        assert frozenset({"dns", "connect", "tls", "ttfb", "wait", "xfer", "total"}) == SLO_KEYS
+
+    def test_does_not_contain_is_estimated(self) -> None:
+        assert "is_estimated" not in SLO_KEYS
+
+    def test_is_immutable(self) -> None:
+        with pytest.raises(AttributeError):
+            SLO_KEYS.add("new_key")  # type: ignore[attr-defined]
+
+
+class TestParseSLOSpec:
+    """Parsing accepts well-formed specs and rejects anything else."""
+
+    def test_single_key(self) -> None:
+        assert parse_slo_spec("total=500") == {"total": 500.0}
+
+    def test_multiple_keys(self) -> None:
+        result = parse_slo_spec("total=500,ttfb=200,connect=100")
+        assert result == {"total": 500.0, "ttfb": 200.0, "connect": 100.0}
+
+    def test_fractional_values(self) -> None:
+        assert parse_slo_spec("ttfb=123.45") == {"ttfb": 123.45}
+
+    def test_whitespace_tolerance(self) -> None:
+        assert parse_slo_spec(" total = 500 , ttfb = 200 ") == {
+            "total": 500.0,
+            "ttfb": 200.0,
+        }
+
+    def test_case_insensitive_keys(self) -> None:
+        assert parse_slo_spec("TOTAL=500,Ttfb=200") == {"total": 500.0, "ttfb": 200.0}
+
+    @pytest.mark.parametrize("key", sorted(SLO_KEYS))
+    def test_every_supported_key(self, key: str) -> None:
+        assert parse_slo_spec(f"{key}=100") == {key: 100.0}
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\t"])
+    def test_empty_spec_rejected(self, raw: str) -> None:
+        with pytest.raises(SLOSpecError, match="empty"):
+            parse_slo_spec(raw)
+
+    def test_empty_item_rejected(self) -> None:
+        with pytest.raises(SLOSpecError, match="Empty item"):
+            parse_slo_spec("total=500,,ttfb=200")
+
+    @pytest.mark.parametrize("raw", ["total", "total=500=1000", "=500"])
+    def test_malformed_item_rejected(self, raw: str) -> None:
+        with pytest.raises(SLOSpecError):
+            parse_slo_spec(raw)
+
+    def test_unknown_key_rejected(self) -> None:
+        with pytest.raises(SLOSpecError, match="Unknown SLO key 'foo'"):
+            parse_slo_spec("foo=500")
+
+    def test_duplicate_key_rejected(self) -> None:
+        with pytest.raises(SLOSpecError, match="Duplicate SLO key 'total'"):
+            parse_slo_spec("total=500,total=600")
+
+    def test_non_numeric_value_rejected(self) -> None:
+        with pytest.raises(SLOSpecError, match="is not a number"):
+            parse_slo_spec("total=fast")
+
+    @pytest.mark.parametrize("value", ["0", "-1", "-0.001", "inf", "nan"])
+    def test_non_positive_or_non_finite_value_rejected(self, value: str) -> None:
+        with pytest.raises(SLOSpecError, match="positive finite number"):
+            parse_slo_spec(f"total={value}")
+
+    def test_returns_new_dict_each_call(self) -> None:
+        first = parse_slo_spec("total=500")
+        second = parse_slo_spec("total=500")
+        assert first == second
+        assert first is not second
+
+
+class TestEvaluateSLO:
+    """Evaluation reports violations only when timings exceed budgets."""
+
+    def test_pass_when_every_metric_under_budget(self) -> None:
+        step = _step(total_ms=100.0, ttfb_ms=50.0)
+        result = evaluate_slo(step, {"total": 500.0, "ttfb": 200.0})
+        assert result.passed is True
+        assert result.violations == ()
+        assert dict(result.thresholds_ms) == {"total": 500.0, "ttfb": 200.0}
+
+    def test_equal_to_threshold_is_pass(self) -> None:
+        step = _step(total_ms=500.0)
+        result = evaluate_slo(step, {"total": 500.0})
+        assert result.passed is True
+
+    def test_fail_when_single_metric_exceeds(self) -> None:
+        step = _step(total_ms=600.0)
+        result = evaluate_slo(step, {"total": 500.0})
+        assert result.passed is False
+        assert len(result.violations) == 1
+        violation = result.violations[0]
+        assert violation.key == "total"
+        assert violation.threshold_ms == 500.0
+        assert violation.actual_ms == 600.0
+        assert violation.delta_ms == pytest.approx(100.0)
+
+    def test_fail_reports_all_violations_in_sorted_order(self) -> None:
+        step = _step(total_ms=600.0, ttfb_ms=300.0, connect_ms=200.0)
+        result = evaluate_slo(
+            step,
+            {"ttfb": 200.0, "total": 500.0, "connect": 100.0},
+        )
+        assert result.passed is False
+        # Sorted alphabetically for deterministic output.
+        assert [v.key for v in result.violations] == ["connect", "total", "ttfb"]
+
+    def test_empty_thresholds_always_pass(self) -> None:
+        step = _step(total_ms=10000.0)
+        result = evaluate_slo(step, {})
+        assert result.passed is True
+        assert dict(result.thresholds_ms) == {}
+
+    @pytest.mark.parametrize("threshold_key", sorted(SLO_KEYS))
+    def test_every_slo_key_maps_to_timing_field(self, threshold_key: str) -> None:
+        """Every key in SLO_KEYS must resolve to a TimingMetrics attribute.
+
+        Parametrised directly over :data:`SLO_KEYS` so that adding a
+        new entry there breaks this test until :func:`evaluate_slo`
+        grows the corresponding mapping.
+        """
+        actual_ms = 200.0
+        timing = TimingMetrics(**{f"{threshold_key}_ms": actual_ms})  # type: ignore[arg-type]
+        step = StepMetrics(url="https://example.com", timing=timing)
+
+        # Threshold is half the measured value → violation on the one key.
+        result = evaluate_slo(step, {threshold_key: actual_ms / 2})
+
+        assert result.passed is False
+        assert len(result.violations) == 1
+        assert result.violations[0].key == threshold_key
+        assert result.violations[0].actual_ms == actual_ms
+
+    def test_unknown_key_raises_spec_error(self) -> None:
+        step = _step(total_ms=100.0)
+        with pytest.raises(SLOSpecError, match="Unknown SLO key"):
+            evaluate_slo(step, {"bogus": 500.0})
+
+    def test_mixed_known_and_unknown_keys_rejected(self) -> None:
+        step = _step(total_ms=100.0)
+        with pytest.raises(SLOSpecError, match="bogus"):
+            evaluate_slo(step, {"total": 500.0, "bogus": 500.0})
+
+    def test_does_not_mutate_input_thresholds(self) -> None:
+        step = _step(total_ms=600.0)
+        thresholds = {"total": 500.0, "ttfb": 100.0}
+        snapshot = dict(thresholds)
+
+        evaluate_slo(step, thresholds)
+
+        assert thresholds == snapshot  # Caller's mapping preserved.
+
+    def test_zero_phase_against_zero_threshold_is_pass(self) -> None:
+        """TLS=0 on plain HTTP should not violate a tight TLS budget."""
+        step = _step(tls_ms=0.0)
+        result = evaluate_slo(step, {"tls": 1.0})
+        assert result.passed is True
+
+
+class TestSLOResult:
+    """``SLOResult.to_dict`` produces stable JSON-ready data."""
+
+    def test_pass_dict_shape(self) -> None:
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+        assert result.to_dict() == {
+            "pass": True,
+            "thresholds_ms": {"total": 500.0},
+            "violations": [],
+        }
+
+    def test_fail_dict_shape(self) -> None:
+        violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=700.0)
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+        payload = result.to_dict()
+        assert payload == {
+            "pass": False,
+            "thresholds_ms": {"total": 500.0},
+            "violations": [
+                {
+                    "key": "total",
+                    "threshold_ms": 500.0,
+                    "actual_ms": 700.0,
+                    "delta_ms": 200.0,
+                }
+            ],
+        }
+
+    def test_evaluate_copies_user_thresholds(self) -> None:
+        """evaluate_slo snapshots the caller's mapping into the result."""
+        thresholds = {"total": 500.0}
+        step = _step(total_ms=100.0)
+
+        result = evaluate_slo(step, thresholds)
+
+        thresholds["total"] = 999.0
+        assert result.thresholds_ms == {"total": 500.0}
+
+    def test_frozen_attribute_reassignment_is_blocked(self) -> None:
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+        with pytest.raises(AttributeError):
+            result.violations = ()  # type: ignore[misc]
+
+    def test_to_dict_thresholds_sorted_for_stable_json(self) -> None:
+        """to_dict emits thresholds in alphabetical key order."""
+        result = SLOResult(
+            thresholds_ms={"total": 500.0, "connect": 100.0, "ttfb": 200.0},
+            violations=(),
+        )
+        payload_keys = list(result.to_dict()["thresholds_ms"].keys())
+        assert payload_keys == ["connect", "total", "ttfb"]
+
+    def test_equality_compares_by_value(self) -> None:
+        violation = SLOViolation(key="total", threshold_ms=500.0, actual_ms=700.0)
+        first = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+        second = SLOResult(thresholds_ms={"total": 500.0}, violations=(violation,))
+        assert first == second
+
+    def test_is_not_hashable(self) -> None:
+        result = SLOResult(thresholds_ms={"total": 500.0}, violations=())
+        with pytest.raises(TypeError):
+            hash(result)
+
+
+class TestSLOViolation:
+    """``SLOViolation.delta_ms`` captures the overrun."""
+
+    def test_delta_is_positive_on_overrun(self) -> None:
+        v = SLOViolation(key="total", threshold_ms=500.0, actual_ms=750.0)
+        assert v.delta_ms == pytest.approx(250.0)
+
+    def test_delta_is_zero_on_boundary(self) -> None:
+        v = SLOViolation(key="total", threshold_ms=500.0, actual_ms=500.0)
+        assert math.isclose(v.delta_ms, 0.0)
+
+    def test_is_immutable(self) -> None:
+        v = SLOViolation(key="total", threshold_ms=500.0, actual_ms=750.0)
+        with pytest.raises(AttributeError):
+            v.threshold_ms = 0.0  # type: ignore[misc]
+
+
+class TestSelectStepForEvaluation:
+    """SLO targets the final successful step of the chain."""
+
+    def test_single_successful_step(self) -> None:
+        step = _step(total_ms=100.0)
+        assert select_step_for_evaluation([step]) is step
+
+    def test_returns_last_step_when_all_succeed(self) -> None:
+        first = _step(total_ms=50.0, step_number=1)
+        second = _step(total_ms=100.0, step_number=2)
+        third = _step(total_ms=150.0, step_number=3)
+        assert select_step_for_evaluation([first, second, third]) is third
+
+    def test_skips_trailing_errors(self) -> None:
+        ok = _step(total_ms=100.0, step_number=1)
+        failed = _step(step_number=2, error="connection refused")
+        assert select_step_for_evaluation([ok, failed]) is ok
+
+    def test_returns_none_when_all_failed(self) -> None:
+        first = _step(step_number=1, error="DNS error")
+        second = _step(step_number=2, error="TCP error")
+        assert select_step_for_evaluation([first, second]) is None
+
+    def test_empty_list_returns_none(self) -> None:
+        assert select_step_for_evaluation([]) is None


### PR DESCRIPTION
## Description

Add `--slo KEY=MS[,KEY=MS...]` flag to gate a single HTTP request on per-phase latency budgets. The final successful step of the redirect chain is compared against the supplied thresholds; a violation still renders the full report (waterfall / compact / metrics / JSON) but exits with code `4`, so CI jobs, cron probes, and Kubernetes readiness checks can branch on the outcome without parsing stderr.

This closes the only cell in the comparison table where `httpstat` was ahead and ships a matching exit-code convention so both tools can be wired through the same CI gate.

Fixes #N/A (feature-only, no tracked issue)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test improvements
- [ ] 🔧 Build/CI/tooling changes

## Changes Made

- **New `httptap.slo` module** with `SLO_KEYS`, `SLOViolation`, `SLOResult`, `SLOSpecError`, `parse_slo_spec`, `evaluate_slo`, and `select_step_for_evaluation`. All public symbols re-exported from the package root for programmatic use.
- **CLI**: `--slo KEY=MS[,KEY=MS...]` added to Output options. Malformed specifications surface as a Rich `SLO Error` panel and return `EXIT_CODE_USAGE` (64).
- **Exit codes**: new `EXIT_CODE_SLO_VIOLATION = 4` (matches `httpstat`). Precedence: usage (64) > fatal (70) > network/TLS (75) > SLO (4) > success (0).
- **Output modes**:
  - **Rich / Compact** — bordered panel after the waterfall / step summary; green ✓ on pass, red ✗ on fail; each violation rendered as `<key>: <actual>ms > <threshold>ms (+<delta>ms)`.
  - **`--metrics-only`** — appends `slo=pass` or `slo=fail slo_violations=<keys>` to the final successful step only; intermediate redirect steps unchanged.
  - **`--json`** — adds `summary.slo = {pass, thresholds_ms, violations[]}`. Each violation records `key`, `threshold_ms`, `actual_ms`, `delta_ms`. Thresholds are emitted in alphabetical order for byte-stable JSON.
- **Extensible `Exporter` Protocol** — `export()` gains kw-only `slo_result` with default `None`; backwards-compatible for existing third-party implementations.
- **Documentation**:
  - New `docs/usage/slo.md` (grammar, evaluation rules, exit-code precedence, per-mode output, CI/cron/Kubernetes recipes).
  - Quick Start, Basic Usage, Output Formats, Troubleshooting & FAQ, and API Reference extended with SLO coverage.
  - README gains a dedicated SLO section, ToC entry, exit-code row for `4`, and the comparison-table cell flipped to ✅ (`--slo`).
  - ROADMAP marks the core checker as shipped; relative budgets, `--slo-file`, and soft-vs-hard SLO remain tracked.

## Testing

**Test environment:**

- OS: macOS 15.4 (also exercised on ubuntu-latest via CI)
- Python version: 3.13
- httptap version: 0.4.8 → 0.5.0 (this PR)

**Tests performed:**

- [x] Ran existing test suite: `uv run pytest`
- [x] Added new tests for new functionality (+79 new tests)
- [x] Manually tested with: see live commands below
- [x] Tested on multiple OS (if applicable): CI runs on Linux / macOS / Windows matrix

**Test commands:**

```bash
# SLO pass (default)
httptap --slo total=5000 https://httpbin.io/get                  # exit 0

# SLO fail (default)
httptap --slo total=1 https://httpbin.io/get                     # exit 4

# Multi-violation (alphabetically sorted)
httptap --slo total=1,ttfb=1,connect=1 https://httpbin.io/get    # exit 4

# Compact + SLO
httptap --compact --slo total=1 https://httpbin.io/get           # exit 4

# Metrics-only + SLO
httptap --metrics-only --slo total=1 https://httpbin.io/get      # exit 4

# JSON export + SLO
httptap --slo total=1,ttfb=1 --json out.json https://httpbin.io/get
jq '.summary.slo' out.json

# Malformed spec
httptap --slo 'bogus=500' https://httpbin.io/get                 # exit 64

# All seven supported keys
httptap --metrics-only --slo dns=1,connect=1,tls=1,ttfb=1,wait=1,xfer=1,total=1 \
  https://httpbin.io/get                                         # exit 4

# Redirect chain + compact + SLO pass
httptap --compact --follow --slo total=500 https://httpbin.io/redirect/1
```
Expected behavior:

- Exit codes follow the documented precedence (network errors always beat SLO violations).
- Violations are reported in alphabetical order of key in ever output format.
- JSON output is byte-stable (thresholds and violations sorted), so diffs and cache keys work.
- When --slo is omitted the output is byte-identical to previous releases (feature is purely additive).

Actual behavior:

Matches expected across all 10 live cases and 562 unit/integration tests (see screenshot below).

Screenshots/Output

Rich --slo total=1:
```
╭──────────────────────────────── ✗ SLO: fail ─────────────────────────────────╮
│ Thresholds: total≤1ms                                                        │
│ Violations:                                                                  │
│   • total: 498.0ms > 1ms (+497.0ms)                                          │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```
--compact --slo total=1:
```
Step 1: 200 GET https://httpbin.io/get | dns=4.5ms connect=95.6ms tls=276.4ms ttfb=506.4ms total=507.7ms | 390 B

╭──────────────────────────────── ✗ SLO: fail ─────────────────────────────────╮
│ Thresholds: total≤1ms                                                        │
│ Violations:                                                                  │
│   • total: 507.7ms > 1ms (+506.7ms)                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
```
--metrics-only --slo total=1:
```
Step 1: dns=50.9 connect=95.8 tls=282.7 ttfb=578.9 total=581.1 status=200 bytes=390 ip=52.70.33.41 family=IPv4 tls_version=TLSv1.2 proxy=direct slo=fail slo_violations=total
```
--json summary.slo:
```
{
  "pass": false,
  "thresholds_ms": {"total": 1.0, "ttfb": 1.0},
  "violations": [
    {"key": "total", "threshold_ms": 1.0, "actual_ms": 497.68, "delta_ms": 496.68},
    {"key": "ttfb",  "threshold_ms": 1.0, "actual_ms": 496.09, "delta_ms": 495.09}
  ]
}
```
Malformed spec → exit 64:
```
╭──────────────────────────────── ❌ SLO Error ────────────────────────────────╮
│                                                                              │
│  Unknown SLO key 'bogus'. Valid keys: connect, dns, tls, total, ttfb,        │
│  wait, xfer.                                                                 │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```
Checklist

- My code follows the Google Python Style Guide
- I have run uv run ruff check . and uv run ruff format .
- I have run uv run mypy httptap and resolved type errors
- I have added tests that prove my fix is effective or that my feature works
- All tests pass locally: uv run pytest (562 passed, 1 skipped)
- I have updated the documentation (if applicable)
- I have added docstrings to new functions/classes
- My changes don't introduce new dependencies (or I've justified them)
- I have checked that my changes work on multiple platforms (if applicable — CI matrix)

Breaking Changes

None. The feature is purely additive:

- --slo is a new optional flag; omitting it preserves the previous output byte-for-byte.
- Exit code 4 is new; existing codes (0, 64, 70, 75) keep their meanings and precedence.
- summary.slo is only emitted when --slo is supplied (missing key for consumers that don't opt in).
- Exporter.export() gained a kw-only slo_result=None parameter; third-party implementations that don't know about it continue to work unchanged because the default is None.

Version impact: minor bump (v0.4.8 → v0.5.0) per SemVer 2.0.0.

Additional Context

- Exit code 4 and the slo=pass / slo=fail metrics tokens deliberately match httpstat's convention so the same CI gate
works for both tools.
- httptap.slo is pure domain code (no Rich / no I/O) and is importable from the package root; the SLO section of
docs/api/overview.md documents programmatic use.
- Future extensions (--slo-file, relative budgets, soft-vs-hard SLO) are tracked in ROADMAP.md and deliberately
out of scope for this PR.

**For Maintainers:**
<!-- This section is for maintainers to fill out during review -->

- [x] Code review completed
- [x] Tests verified
- [x] Documentation reviewed
- [x] Ready to merge