### PR TITLE
fix: validate_url should require a non-empty host

### DIFF
--- a/httptap/utils.py
+++ b/httptap/utils.py
@@ -304,6 +304,12 @@ def validate_url(url: str) -> bool:
         True
         >>> validate_url("ftp://example.com")
         False
+        >>> validate_url("https://")
+        False
 
     """
-    return bool(re.match(r"^https?://", url, flags=re.IGNORECASE))
+    if not url or not url.strip():
+        return False
+    if any(ch.isspace() for ch in url):
+        return False
+    return bool(re.match(r"^https?://\S+", url, flags=re.IGNORECASE))

--- a/httptap/utils.py
+++ b/httptap/utils.py
@@ -290,6 +290,12 @@ def read_request_data(data_arg: str | None) -> tuple[bytes | None, dict[str, str
     return data, headers
 
 
+# Valid HTTP/HTTPS URL: scheme followed by at least one non-whitespace
+# character. ``fullmatch`` rejects empty/whitespace-only input and any URL
+# containing embedded whitespace (e.g. a trailing newline) in a single pass.
+_URL_RE = re.compile(r"https?://\S+", flags=re.IGNORECASE)
+
+
 def validate_url(url: str) -> bool:
     """Validate URL format.
 
@@ -308,8 +314,4 @@ def validate_url(url: str) -> bool:
         False
 
     """
-    if not url or not url.strip():
-        return False
-    if any(ch.isspace() for ch in url):
-        return False
-    return bool(re.match(r"^https?://\S+", url, flags=re.IGNORECASE))
+    return _URL_RE.fullmatch(url) is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,6 +260,19 @@ class TestValidateUrl:
         """Test that URLs without scheme are invalid."""
         assert validate_url("example.com") is False
 
+    def test_validate_url_with_empty_host(self) -> None:
+        """URLs with an empty host (just the scheme) should be invalid."""
+        assert validate_url("https://") is False
+        assert validate_url("http://") is False
+        assert validate_url("") is False
+        assert validate_url("   ") is False
+
+    def test_validate_url_with_whitespace(self) -> None:
+        """URLs containing whitespace should be invalid."""
+        assert validate_url("https://example.com\n") is False
+        assert validate_url("https://example.com\tfoo") is False
+        assert validate_url("https://example.com foo") is False
+
 
 class TestCreateSSLContext:
     """Tests for the create_ssl_context helper."""


### PR DESCRIPTION
## Summary

`httptap/utils.validate_url` only checked the URL scheme prefix (`^https?://`) and accepted anything after it. This let two bad inputs slip through validation and surface as a confusing `❌ Internal Error` (`Invalid URL: missing hostname`) in the CLI:

- `https://` (scheme with an empty host)
- `https://example.com\n` (embedded whitespace, e.g. pasted with a trailing newline from a shell)

## Changes

- `httptap/utils.py` — extend the regex to require at least one non-whitespace character after the scheme (`^https?://\S+`), and reject empty / whitespace-only input up front.
- `tests/test_utils.py` — add regression tests for the empty host, empty string, whitespace-only string, and embedded whitespace cases.

## Before / After

```python
# Before
validate_url("https://")            # -> True   ❌
validate_url("https://example.com\n")  # -> True   ❌

# After
validate_url("https://")            # -> False  ✅
validate_url("https://example.com\n")  # -> False  ✅
```

All existing tests pass (515 passed, 1 skipped).

— Sent via @AmSach bot