### PR TITLE
fix(utils): require a non-empty host in validate_url

### DIFF
--- a/httptap/utils.py
+++ b/httptap/utils.py
@@ -12,6 +12,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
 try:  # pragma: no cover - exercised indirectly
     from datetime import UTC  # type: ignore[attr-defined]
@@ -32,7 +33,6 @@ __all__ = [
     "validate_url",
 ]
 
-# Headers that should have their values masked for security
 SENSITIVE_HEADERS: set[str] = {
     "authorization",
     "cookie",
@@ -41,7 +41,6 @@ SENSITIVE_HEADERS: set[str] = {
     "x-api-key",
 }
 
-# Pattern for masking - show first 4 and last 4 characters
 MASK_PATTERN = "****"
 
 
@@ -170,7 +169,6 @@ def create_ssl_context(*, verify_ssl: bool, ca_bundle_path: str | None = None) -
     if verify_ssl:
         context = ssl.create_default_context()
 
-        # Load custom CA bundle if provided
         if ca_bundle_path:
             try:
                 context.load_verify_locations(cafile=ca_bundle_path)
@@ -183,7 +181,6 @@ def create_ssl_context(*, verify_ssl: bool, ca_bundle_path: str | None = None) -
     # For legacy mode create a mutable context allowing older protocols.
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)
 
-    # Disable certificate verification and hostname checks
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
 
@@ -290,8 +287,16 @@ def read_request_data(data_arg: str | None) -> tuple[bytes | None, dict[str, str
     return data, headers
 
 
+_WHITESPACE_RE = re.compile(r"\s")
+
+
 def validate_url(url: str) -> bool:
     """Validate URL format.
+
+    Requires an http/https scheme and a non-empty host. A scheme alone is not
+    enough: ``https:///path`` and ``https://?query`` parse to an empty host and
+    would fail at connection time with an opaque error, so they are rejected
+    here where the message can be actionable.
 
     Args:
         url: URL string to validate.
@@ -304,6 +309,19 @@ def validate_url(url: str) -> bool:
         True
         >>> validate_url("ftp://example.com")
         False
+        >>> validate_url("https://")
+        False
+        >>> validate_url("https:///path")
+        False
 
     """
-    return bool(re.match(r"^https?://", url, flags=re.IGNORECASE))
+    if _WHITESPACE_RE.search(url):
+        return False
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        # Malformed authority, e.g. an unterminated IPv6 literal.
+        return False
+
+    return parts.scheme in {"http", "https"} and bool(parts.hostname)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,6 +260,67 @@ class TestValidateUrl:
         """Test that URLs without scheme are invalid."""
         assert validate_url("example.com") is False
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://",
+            "http://",
+            "   ",
+        ],
+    )
+    def test_validate_scheme_without_host(self, url: str) -> None:
+        """Test that a scheme with no host at all is invalid."""
+        assert validate_url(url) is False
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https:///path",
+            "https://?query",
+            "https://#fragment",
+            "https://:8080",
+            "https://@",
+            "http://:@",
+        ],
+    )
+    def test_validate_empty_host_with_trailing_component(self, url: str) -> None:
+        """Test that an empty host is invalid even when a path/query/port follows.
+
+        These parse to an empty host and would otherwise fail at connection
+        time with an opaque error instead of a validation message.
+        """
+        assert validate_url(url) is False
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com\n",
+            "https://example.com\tfoo",
+            "https://example.com foo",
+            " https://example.com",
+        ],
+    )
+    def test_validate_url_with_whitespace(self, url: str) -> None:
+        """Test that URLs containing whitespace are invalid."""
+        assert validate_url(url) is False
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://user:pw@example.com",
+            "https://[::1]:8080/path",
+            "https://192.168.0.1",
+            "HTTPS://EXAMPLE.COM",
+        ],
+    )
+    def test_validate_accepts_valid_authority_forms(self, url: str) -> None:
+        """Test that userinfo, IPv6 literals, IPs and uppercase schemes stay valid."""
+        assert validate_url(url) is True
+
+    def test_validate_unterminated_ipv6_literal(self) -> None:
+        """Test that a malformed authority is rejected rather than raising."""
+        assert validate_url("https://[::1") is False
+
 
 class TestCreateSSLContext:
     """Tests for the create_ssl_context helper."""
@@ -336,14 +397,11 @@ class TestCreateSSLContext:
         real_ctx = ssl.create_default_context()
         monkeypatch.setattr(real_ctx, "load_verify_locations", mock_load_verify_locations)
 
-        # Patch create_default_context to return our mocked context
         monkeypatch.setattr(ssl, "create_default_context", lambda: real_ctx)
 
         ctx = create_ssl_context(verify_ssl=True, ca_bundle_path=str(ca_bundle))
 
-        # Should have called load_verify_locations with our CA bundle
         assert load_called_with["cafile"] == str(ca_bundle)
-        # Should still have verification enabled
         assert ctx.verify_mode == ssl.CERT_REQUIRED
         assert ctx.check_hostname is True
 
@@ -357,7 +415,6 @@ class TestCreateSSLContext:
 
         ctx = create_ssl_context(verify_ssl=False, ca_bundle_path=str(ca_bundle))
 
-        # Should have verification disabled regardless of ca_bundle_path
         assert ctx.verify_mode == ssl.CERT_NONE
         assert ctx.check_hostname is False
 
@@ -365,7 +422,6 @@ class TestCreateSSLContext:
         """Test that None ca_bundle_path uses system CA bundle."""
         ctx = create_ssl_context(verify_ssl=True, ca_bundle_path=None)
 
-        # Should use default system CA (verification enabled)
         assert ctx.verify_mode == ssl.CERT_REQUIRED
         assert ctx.check_hostname is True
 
@@ -548,7 +604,6 @@ class TestReadRequestData:
     ) -> None:
         """Test that file extension takes priority over content inspection."""
         json_file = tmp_path / "data.json"
-        # Write non-JSON content to .json file
         json_file.write_text("not valid json")
 
         content, headers = read_request_data(f"@{json_file}")


### PR DESCRIPTION
Replaces #181 and #182, which propose a byte-identical diff that does not deliver what its title promises.

## Why those PRs are not enough

Both propose `re.compile(r"https?://\S+").fullmatch(url)`. That fixes the one literal example (`https://`) but not the class of bug, because `\S+` matches *any* non-whitespace, including a path, query or port with no host in front of it. Verified against the proposed regex:

| Input | Proposed regex | Actual host |
|---|---|---|
| `https:///path` | ✅ valid | `None` |
| `https://?query` | ✅ valid | `None` |
| `https://#frag` | ✅ valid | `None` |
| `https://:8080` | ✅ valid | `None` |
| `https://@` | ✅ valid | `None` |
| `http://:@` | ✅ valid | `None` |

Six empty-host inputs still pass a check whose stated purpose is to require a non-empty host. A regex over the scheme prefix cannot express "has a host" without reimplementing URL parsing.

## Impact

`validate_url` is a CLI pre-flight check (`cli.py:396`) whose job is to produce an actionable message before any connection is attempted. httpx accepts these strings with `host=''`, so today they fail later with an opaque error. On `main`:

```
$ httptap 'https:///path'
╭─ HTTP Tap Analysis ─╮
│ 🔍 Analyzing: https:///path   ← proceeds, then fails obscurely
```

With this change:

```
$ httptap 'https:///path'
╭─ ❌ Validation Error ─╮
│ Invalid URL: 'https:///path'
```

## Approach

Defer to `urllib.parse.urlsplit` and require an http/https scheme **and** a non-empty hostname. Embedded whitespace is rejected up front, and a malformed authority (unterminated IPv6 literal) raises `ValueError` from `urlsplit` and is treated as invalid rather than propagating.

Userinfo, IPv6 literals, bare IPs, ports and uppercase schemes stay valid. Every assertion from #181/#182's own tests passes here too — this is a strict superset of their behaviour.

## Tests

18 new cases across four parametrized groups: scheme-without-host, empty-host-with-trailing-component (the six above), whitespace, and valid authority forms, plus the malformed-IPv6 case. 603 passing, coverage stays at 100%.

## Unrelated cleanup

Removed comments that restated the line below them, plus one on `MASK_PATTERN` that described `mask_sensitive_value`'s `show_chars` parameter rather than the constant it sat above. Happy to split this out if you'd rather keep the fix isolated.

## Credit

The empty-host problem was reported and diagnosed in #181 by @AmSach — this PR keeps their test cases and extends the fix to cover the rest of the class.
