### PR TITLE
docs(mkdocs): point site_url to docs.httptap.dev

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: httptap Documentation
-site_url: https://httptap.dev/
+site_url: https://docs.httptap.dev/
 site_description: HTTP request visualizer with detailed timing breakdown
 site_author: Sergei Ozeranskii
 repo_url: https://github.com/ozeranskii/httptap


### PR DESCRIPTION
The standalone site at `https://httptap.dev/` has been removed, so all site references now lead to the documentation at `https://docs.httptap.dev/`.

## Changes
- `mkdocs.yml`: `site_url` `https://httptap.dev/` → `https://docs.httptap.dev/` (fixes the canonical URL / sitemap / SEO tags emitted by mkdocs-material).

## Repo settings (done out-of-band, no code change)
- Repository **Website** (homepage) updated `https://httptap.dev/` → `https://docs.httptap.dev/`.
- GitHub Pages custom domain already `docs.httptap.dev` — no change needed.

## Intentionally left unchanged
These are not site links and must not become a docs URL:
- `CODE_OF_CONDUCT.md` — `conduct@httptap.dev` (email address)
- `.github/workflows/release.yml` — `noreply@httptap.dev` (git author email)
- `GOVERNANCE.md` — `httptap.dev` referenced as the owned **domain** (which still serves the `docs.` subdomain)