### PR TITLE
docs(i18n): add Simplified Chinese translation and mkdocstrings API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Fetch all history for git-revision-date-localized
+          persist-credentials: false # Build job never pushes; do not persist the token
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,11 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions: {}
@@ -16,9 +21,43 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  DISABLE_MKDOCS_2_WARNING: "true"
+
 jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Fetch all history for git-revision-date-localized
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked --group docs
+
+      - name: Build (strict)
+        run: uv run mkdocs build --strict
+
   deploy:
     name: Deploy Documentation
+    if: github.event_name != 'pull_request'
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,3 +1,7 @@
+---
+description: Where to find the httptap changelog and how it is formatted.
+---
+
 # Changelog
 
 All notable changes to httptap are documented in the

--- a/docs/about/changelog.zh.md
+++ b/docs/about/changelog.zh.md
@@ -1,0 +1,20 @@
+---
+description: 在哪里查看 httptap 的变更日志及其格式说明。
+---
+
+# 变更日志
+
+httptap 的所有重要变更都记录在仓库中的
+[CHANGELOG.md](https://github.com/ozeranskii/httptap/blob/main/CHANGELOG.md) 文件里。
+
+其格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，
+并且本项目遵循 [语义化版本控制](https://semver.org/spec/v2.0.0.html)。
+
+## 链接
+
+- [仓库中的 CHANGELOG.md](https://github.com/ozeranskii/httptap/blob/main/CHANGELOG.md)
+- [GitHub Releases](https://github.com/ozeranskii/httptap/releases)
+
+---
+
+*权威的变更日志维护在仓库中，并由发布工作流使用 [git-cliff](https://git-cliff.org/) 自动更新。*

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,3 +1,7 @@
+---
+description: httptap is released under the Apache License 2.0.
+---
+
 # License
 
 httptap is licensed under the Apache License 2.0.

--- a/docs/about/license.zh.md
+++ b/docs/about/license.zh.md
@@ -1,0 +1,89 @@
+---
+description: httptap 基于 Apache License 2.0 发布。
+---
+
+# 许可证
+
+httptap 基于 Apache License 2.0 授权。
+
+## Apache License 2.0
+
+```text
+Copyright 2025-2026 Sergei Ozeranskii
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+## 这意味着什么
+
+Apache License 2.0 是一种宽松的开源许可证，它允许你：
+
+✅ **使用** —— 出于任何目的使用 httptap，无论商业或非商业
+✅ **修改** —— 修改源代码以满足你的需求
+✅ **分发** —— 分发原始或修改后的版本
+✅ **再授权** —— 依据不同条款向他人授予权利
+✅ **商业使用** —— 在商业产品中使用 httptap
+
+## 你的责任
+
+在使用 httptap 时，你必须：
+
+- **包含许可证** —— 包含一份 Apache License 2.0 的副本
+- **声明变更** —— 记录你所做的任何修改
+- **包含声明** —— 保留版权和署名声明
+- **包含 NOTICE** —— 如存在 NOTICE 文件，则包含之
+
+## 专利授权
+
+Apache License 2.0 包含一项从贡献者到用户的明确专利许可。这意味着：
+
+- 贡献者向你授予其持有的、使用 httptap 所必需的任何专利的许可
+- 如果你就与 httptap 相关的专利侵权起诉任何人，你的许可将终止
+
+## 无担保
+
+httptap 按“原样”（"AS IS"）提供，不附带任何形式的担保。详情请参阅完整的许可证文本。
+
+## 完整许可证文本
+
+如需完整的许可证文本，请参阅：
+
+- [仓库中的 LICENSE 文件](https://github.com/ozeranskii/httptap/blob/main/LICENSE)
+- [Apache License 2.0 官方文本](https://www.apache.org/licenses/LICENSE-2.0)
+
+## 第三方许可证
+
+httptap 依赖若干开源项目：
+
+### 直接依赖
+
+| 软件包    | 许可证       | 链接                                  |
+|-----------|--------------|---------------------------------------|
+| httpx     | BSD-3-Clause | https://github.com/encode/httpx       |
+| httpcore  | BSD-3-Clause | https://github.com/encode/httpcore    |
+| Rich      | MIT          | https://github.com/Textualize/rich    |
+| dnspython | ISC          | https://github.com/rthalley/dnspython |
+
+所有依赖均使用与 Apache 2.0 兼容的宽松许可证。
+
+## 问题咨询
+
+如有许可相关问题，请：
+
+- 在 [GitHub](https://github.com/ozeranskii/httptap/issues) 上创建 issue
+- 联系维护者
+
+---
+
+*本页仅提供摘要。[完整许可证文本](https://github.com/ozeranskii/httptap/blob/main/LICENSE)才是
+权威来源。*

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,75 +1,17 @@
+---
+title: Core Components
+description: Reference for HTTPTapAnalyzer, the core data models, and utility helpers.
+---
+
 # Core Components
 
-This page documents the core classes and functions in httptap.
+This page documents the core class and data models of httptap, rendered directly from the
+source docstrings so signatures and defaults always match the installed version.
 
 ## HTTPTapAnalyzer
 
-The main analyzer class that orchestrates HTTP request analysis.
-
-### Constructor
-
-```python
-HTTPTapAnalyzer(
-    *,
-    follow_redirects: bool = False,
-    timeout: float = 20.0,
-    http2: bool = True,
-    verify_ssl: bool = True,
-    ca_bundle_path: str | None = None,
-    max_redirects: int = 10,
-    request_executor: RequestExecutor | None = None,
-    proxy: ProxyTypes | None = None,
-    dns_resolver: DNSResolver | None = None,
-    tls_inspector: TLSInspector | None = None,
-    timing_collector_factory: type[TimingCollector] | None = None,
-)
-```
-
-**Parameters:**
-
-- `follow_redirects` - Whether to follow 3xx redirects
-- `timeout` - Request timeout in seconds (default 20)
-- `http2` - Enable HTTP/2 support (default True)
-- `verify_ssl` - Whether to verify TLS certificates
-- `ca_bundle_path` - Path to custom CA certificate bundle (PEM format)
-- `max_redirects` - Maximum number of redirects to follow
-- `request_executor` - Custom request executor implementation (optional)
-- `proxy` - Proxy URL (http/https/socks5/socks5h) for all requests
-- `dns_resolver` - Custom DNS resolver implementation (optional)
-- `tls_inspector` - Custom TLS inspector implementation (optional)
-- `timing_collector_factory` - Factory class for creating timing collectors (optional)
-
-If not provided, default implementations are used.
-
-### Methods
-
-#### analyze_url()
-
-```python
-def analyze_url(
-    self,
-    url: str,
-    *,
-    method: HTTPMethod = HTTPMethod.GET,
-    content: bytes | None = None,
-    headers: Mapping[str, str] | None = None,
-) -> list[StepMetrics]
-```
-
-Analyze an HTTP request and return detailed timing information.
-
-**Parameters:**
-
-- `url` - The URL to analyze (must include scheme: http:// or https://)
-- `method` - HTTP method to use (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
-- `content` - Optional request body as bytes
-- `headers` - Optional custom HTTP headers
-
-**Returns:**
-
-- `list[StepMetrics]` - List of request steps (one per redirect)
-
-**Example:**
+The main analyzer class that orchestrates HTTP request analysis, including redirect following
+and per-step metric collection.
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -82,133 +24,35 @@ steps = analyzer.analyze_url(
 )
 ```
 
-## Data Models
+::: httptap.analyzer.HTTPTapAnalyzer
 
-### StepMetrics
+## Data models
 
-Represents a single HTTP request/response cycle.
+All models are `@dataclass(slots=True)` and expose `to_dict()` for JSON export.
 
-```python
-@dataclass(slots=True)
-class StepMetrics:
-    url: str = ""  # Request URL
-    step_number: int = 1  # Step number in redirect chain
-    timing: TimingMetrics = field(default_factory=...)  # Timing information
-    network: NetworkInfo = field(default_factory=...)  # Network details
-    response: ResponseInfo = field(default_factory=...)  # Response data
-    error: str | None = None  # Error message if failed
-    note: str | None = None  # Additional notes
-    proxied_via: str | None = None  # Proxy URL used, if any
-    request_method: str | None = None  # HTTP method used
-    request_headers: dict[str, str] = field(...)  # Request headers (sanitized)
-    request_body_bytes: int = 0  # Size of request body
-```
+::: httptap.models.StepMetrics
 
-### TimingMetrics
+::: httptap.models.TimingMetrics
 
-Contains detailed timing breakdown for the request. All values are in milliseconds.
+::: httptap.models.NetworkInfo
 
-```python
-@dataclass(slots=True)
-class TimingMetrics:
-    dns_ms: float = 0.0  # DNS resolution time
-    connect_ms: float = 0.0  # TCP connection time
-    tls_ms: float = 0.0  # TLS handshake time
-    ttfb_ms: float = 0.0  # Time to first byte
-    total_ms: float = 0.0  # Total request time
-    wait_ms: float = 0.0  # Server processing time (derived)
-    xfer_ms: float = 0.0  # Body transfer time (derived)
-    is_estimated: bool = False  # Whether timing is estimated
-```
+::: httptap.models.ResponseInfo
 
-Call `calculate_derived()` after populating raw timing values to compute `wait_ms` and `xfer_ms`.
+## Utility functions
 
-### NetworkInfo
+::: httptap.utils.validate_url
 
-Contains network-level details about the connection. All fields are optional.
+::: httptap.utils.sanitize_headers
 
-```python
-@dataclass(slots=True)
-class NetworkInfo:
-    ip: str | None = None  # Resolved IP address
-    ip_family: str | None = None  # "IPv4" or "IPv6"
-    http_version: str | None = None  # HTTP protocol version
-    tls_version: str | None = None  # TLS protocol version
-    tls_cipher: str | None = None  # Cipher suite name
-    cert_cn: str | None = None  # Certificate common name
-    cert_days_left: int | None = None  # Days until certificate expires
-    cert_sans: list[str] = field(default_factory=list)  # Subject Alternative Names (DNS)
-    cert_issuer: str | None = None  # Issuer common name
-    cert_serial: str | None = None  # Certificate serial number (hex)
-    cert_not_before: datetime | None = None  # Validity start
-    cert_not_after: datetime | None = None  # Validity end
-    tls_verified: bool | None = None  # Whether TLS verification was enforced
-    tls_custom_ca: bool | None = None  # True when custom CA bundle was used
-```
+::: httptap.utils.parse_http_date
 
-### ResponseInfo
-
-Contains HTTP response metadata.
-
-```python
-@dataclass(slots=True)
-class ResponseInfo:
-    status: int | None = None  # HTTP status code
-    bytes: int = 0  # Response body size
-    content_type: str | None = None  # Content-Type header
-    server: str | None = None  # Server header
-    date: datetime | None = None  # Response date (parsed)
-    location: str | None = None  # Location header (redirects)
-    headers: dict[str, str] = field(...)  # Sanitized response headers
-```
-
-## Utility Functions
-
-### validate_url()
-
-Validate that a URL is a valid HTTP/HTTPS URL.
-
-```python
-from httptap.utils import validate_url
-
-validate_url("https://httpbin.io")  # True
-validate_url("ftp://example.com")  # False
-```
-
-### sanitize_headers()
-
-Mask sensitive header values (Authorization, Cookie, API keys).
-
-```python
-from httptap.utils import sanitize_headers
-
-sanitize_headers({"Authorization": "Bearer secret123"})
-# {'Authorization': 'Bear****t123'}
-```
-
-### parse_http_date()
-
-Parse HTTP date header to datetime.
-
-```python
-from httptap.utils import parse_http_date
-
-dt = parse_http_date("Mon, 22 Oct 2025 12:00:00 GMT")
-```
-
-### create_ssl_context()
-
-Create an SSL context with configurable verification and optional custom CA bundle.
-
-```python
-from httptap.utils import create_ssl_context
-
-ctx = create_ssl_context(verify_ssl=True, ca_bundle_path="/path/to/ca.pem")
-```
+::: httptap.utils.create_ssl_context
 
 ## Constants
 
-### Timeouts and Limits
+Selected values from `httptap.constants` (see the module source for the full set):
+
+### Timeouts and limits
 
 ```python
 from httptap.constants import (
@@ -219,30 +63,24 @@ from httptap.constants import (
 )
 ```
 
-### Exit Codes
+### Exit codes
 
 ```python
 from httptap.constants import (
-    EXIT_CODE_OK,  # 0 - Success
-    EXIT_CODE_USAGE,  # 64 - Invalid arguments
-    EXIT_CODE_SOFTWARE,  # 70 - Internal error
-    EXIT_CODE_TEMPFAIL,  # 75 - Network/TLS error
+    EXIT_CODE_OK,  # 0  - Success (os.EX_OK)
+    EXIT_CODE_USAGE,  # 64 - Invalid arguments (os.EX_USAGE)
+    EXIT_CODE_SOFTWARE,  # 70 - Internal error (os.EX_SOFTWARE)
+    EXIT_CODE_TEMPFAIL,  # 75 - Network/TLS error (os.EX_TEMPFAIL)
 )
 ```
 
-## Example: Complete Usage
+## Example: complete usage
 
 ```python
 from httptap import HTTPTapAnalyzer
 
-# Create analyzer with custom settings
-analyzer = HTTPTapAnalyzer(
-    follow_redirects=True,
-    timeout=30.0,
-    http2=True,
-)
+analyzer = HTTPTapAnalyzer(follow_redirects=True, timeout=30.0, http2=True)
 
-# Analyze with custom headers
 steps = analyzer.analyze_url(
     "https://httpbin.io/bearer",
     headers={
@@ -252,7 +90,6 @@ steps = analyzer.analyze_url(
     },
 )
 
-# Process results
 for step in steps:
     print(f"Step {step.step_number}: {step.url}")
     print(f"  Status: {step.response.status}")
@@ -263,10 +100,6 @@ for step in steps:
     print(f"  Total: {step.timing.total_ms:.2f}ms")
     if step.network.ip:
         print(f"  IP: {step.network.ip} ({step.network.ip_family})")
-    if step.network.http_version:
-        print(f"  HTTP: {step.network.http_version}")
-    if step.network.tls_version:
-        print(f"  TLS: {step.network.tls_version}")
     if step.network.cert_cn:
         print(f"  Certificate: {step.network.cert_cn} (expires in {step.network.cert_days_left} days)")
 ```

--- a/docs/api/interfaces.md
+++ b/docs/api/interfaces.md
@@ -1,51 +1,33 @@
+---
+title: Protocol Interfaces
+description: Protocol contracts and worked examples for extending httptap with custom implementations.
+---
+
 # Protocol Interfaces
 
-httptap uses Protocol classes (PEP 544) for structural subtyping. This allows you to provide custom implementations
-without inheriting from base classes.
+httptap uses `Protocol` classes (PEP 544) for structural subtyping, so you can supply custom
+implementations without inheriting from any base class.
 
-## Why Protocols?
+## Why protocols?
 
-Protocols provide:
+- **Duck typing with type safety** — type checkers verify your implementation
+- **No inheritance required** — just implement the methods
+- **Clear contracts** — explicit interface definitions
+- **Easy testing** — simple to mock and substitute
 
-- **Duck typing with type safety** - Type checkers verify your implementation
-- **No inheritance required** - Just implement the methods
-- **Clear contracts** - Explicit interface definitions
-- **Easy testing** - Simple to mock and substitute
+The interface contracts below are rendered from source. Each is followed by a worked custom
+implementation you can adapt.
 
 ## DNSResolver
 
-Interface for DNS resolution implementations.
+::: httptap.interfaces.DNSResolver
 
-### Protocol Definition
+httptap dials the resolved IP address directly while keeping the original hostname for the
+`Host` header and TLS SNI. IPv6 addresses are bracketed automatically; implementations only
+need to return a valid `(ip, family, duration_ms)` tuple. `family` is `"IPv4"`, `"IPv6"`, or
+`"AF_<num>"` for other address families.
 
-```python
-from typing import Protocol
-
-
-class DNSResolver(Protocol):
-    def resolve(self, host: str, port: int, timeout: float) -> tuple[str, str, float]:
-        """Resolve hostname to IP address.
-
-        Args:
-            host: Hostname to resolve
-            port: Port number (may influence resolution)
-            timeout: Maximum time to wait in seconds
-
-        Returns:
-            Tuple of (ip_address, family, duration_ms) where:
-            - ip_address: Resolved IP address string
-            - family: "IPv4" or "IPv6"
-            - duration_ms: Resolution time in milliseconds
-
-        Raises:
-            Exception: If resolution fails
-        """
-        ...
-```
-
-httptap dials the resolved IP address directly while keeping the original hostname for the `Host` header and TLS SNI. IPv6 addresses are bracketed automatically; implementations only need to return a valid IP/family tuple.
-
-### Example Implementation
+### Example implementation
 
 ```python
 import socket
@@ -53,25 +35,18 @@ import time
 
 
 class CustomDNSResolver:
-    def resolve(self, host: str, port: int, timeout: float):
+    def resolve(self, host: str, port: int, timeout: float) -> tuple[str, str, float]:
         start = time.perf_counter()
-
         try:
-            # Use getaddrinfo for resolution
             addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
             ip_address = addr_info[0][4][0]
-
-            # Determine IP family
             family = "IPv6" if ":" in ip_address else "IPv4"
-
             duration_ms = (time.perf_counter() - start) * 1000
             return ip_address, family, duration_ms
-
         except socket.gaierror as e:
             raise Exception(f"DNS resolution failed: {e}")
 
 
-# Usage
 from httptap import HTTPTapAnalyzer
 
 analyzer = HTTPTapAnalyzer(dns_resolver=CustomDNSResolver())
@@ -79,34 +54,9 @@ analyzer = HTTPTapAnalyzer(dns_resolver=CustomDNSResolver())
 
 ## TLSInspector
 
-Interface for TLS connection and certificate inspection.
+::: httptap.interfaces.TLSInspector
 
-### Protocol Definition
-
-```python
-from typing import Protocol
-from httptap.models import NetworkInfo
-
-
-class TLSInspector(Protocol):
-    def inspect(self, host: str, port: int, timeout: float) -> NetworkInfo:
-        """Inspect TLS connection and certificate.
-
-        Args:
-            host: Hostname to connect to
-            port: Port number
-            timeout: Maximum time to wait in seconds
-
-        Returns:
-            NetworkInfo object with TLS version, cipher, and certificate data.
-
-        Raises:
-            Exception: If inspection fails
-        """
-        ...
-```
-
-### Example Implementation
+### Example implementation
 
 ```python
 import ssl
@@ -118,8 +68,6 @@ from httptap.models import NetworkInfo
 
 class CustomTLSInspector:
     def inspect(self, host: str, port: int, timeout: float) -> NetworkInfo:
-        start = time.perf_counter()
-
         context = ssl.create_default_context()
         with socket.create_connection((host, port), timeout=timeout) as sock:
             with context.wrap_socket(sock, server_hostname=host) as ssock:
@@ -138,7 +86,6 @@ class CustomTLSInspector:
         )
 
 
-# Usage
 from httptap import HTTPTapAnalyzer
 
 analyzer = HTTPTapAnalyzer(tls_inspector=CustomTLSInspector())
@@ -146,41 +93,12 @@ analyzer = HTTPTapAnalyzer(tls_inspector=CustomTLSInspector())
 
 ## TimingCollector
 
-Interface for HTTP request timing implementations. A new collector instance is created for each request in the chain.
+A new collector instance is created for each request in the chain, so pass the **class**
+(a factory), not an instance.
 
-### Protocol Definition
+::: httptap.interfaces.TimingCollector
 
-```python
-from typing import Protocol
-from httptap.models import TimingMetrics
-
-
-class TimingCollector(Protocol):
-    def mark_dns_start(self) -> None:
-        """Mark the start of DNS resolution phase."""
-
-    def mark_dns_end(self) -> None:
-        """Mark the end of DNS resolution phase."""
-
-    def mark_request_start(self) -> None:
-        """Mark the start of HTTP request phase."""
-
-    def mark_ttfb(self) -> None:
-        """Mark the time to first byte (headers received)."""
-
-    def mark_request_end(self) -> None:
-        """Mark the end of HTTP request (body fully received)."""
-
-    def get_metrics(self) -> TimingMetrics:
-        """Calculate and return timing metrics.
-
-        Returns:
-            TimingMetrics with all phase durations calculated.
-        """
-        ...
-```
-
-### Example Implementation
+### Example implementation
 
 ```python
 import time
@@ -188,8 +106,6 @@ from httptap.models import TimingMetrics
 
 
 class CustomTimingCollector:
-    """Timing collector using perf_counter."""
-
     def __init__(self) -> None:
         self._dns_start = 0.0
         self._dns_end = 0.0
@@ -221,7 +137,7 @@ class CustomTimingCollector:
         return metrics
 
 
-# Usage: pass the class (not an instance) as factory
+# Pass the class (not an instance) as the factory:
 from httptap import HTTPTapAnalyzer
 
 analyzer = HTTPTapAnalyzer(timing_collector_factory=CustomTimingCollector)
@@ -229,179 +145,113 @@ analyzer = HTTPTapAnalyzer(timing_collector_factory=CustomTimingCollector)
 
 ## Visualizer
 
-Interface for custom output visualization.
+::: httptap.interfaces.Visualizer
 
-### Protocol Definition
-
-```python
-from typing import Protocol
-from httptap.models import StepMetrics
-
-
-class Visualizer(Protocol):
-    def render(self, step: StepMetrics) -> None:
-        """Render a single request step for display.
-
-        Args:
-            step: Step metrics containing timing, network, and response data.
-        """
-        ...
-```
-
-### Example Implementation
+### Example implementation
 
 ```python
 from httptap.models import StepMetrics
 
 
 class SimpleVisualizer:
-    """Simple text-based visualizer."""
-
     def render(self, step: StepMetrics) -> None:
         print(f"Step {step.step_number}: {step.url}")
         print(f"  Status: {step.response.status}")
-        print(f"  Timing:")
         print(f"    DNS:     {step.timing.dns_ms:8.2f}ms")
         print(f"    Connect: {step.timing.connect_ms:8.2f}ms")
         print(f"    TLS:     {step.timing.tls_ms:8.2f}ms")
         print(f"    TTFB:    {step.timing.ttfb_ms:8.2f}ms")
         print(f"    Total:   {step.timing.total_ms:8.2f}ms")
-        print()
 
 
-# Usage
 from httptap import HTTPTapAnalyzer
 
 analyzer = HTTPTapAnalyzer()
-steps = analyzer.analyze_url("https://httpbin.io")
-
-visualizer = SimpleVisualizer()
-for step in steps:
-    visualizer.render(step)
+for step in analyzer.analyze_url("https://httpbin.io"):
+    SimpleVisualizer().render(step)
 ```
 
 ## Exporter
 
-Interface for custom data export formats.
+::: httptap.interfaces.Exporter
 
-### Protocol Definition
+Concrete exporters may embed an optional SLO evaluation via the keyword-only `slo_result`
+argument; see the built-in [`JSONExporter`](overview.md#httptap.exporter.JSONExporter).
 
-```python
-from typing import Protocol
-from collections.abc import Sequence
-from httptap.models import StepMetrics
-
-
-class Exporter(Protocol):
-    def export(
-        self,
-        steps: Sequence[StepMetrics],
-        initial_url: str,
-        output_path: str,
-    ) -> None:
-        """Export request data to file.
-
-        Args:
-            steps: Sequence of request steps to export
-            initial_url: The initial URL that was analyzed
-            output_path: Path to output file
-
-        Raises:
-            IOError: If file cannot be written
-        """
-        ...
-```
-
-### Example Implementation
+### Example implementation
 
 ```python
 import yaml
 from collections.abc import Sequence
 from httptap.models import StepMetrics
+from httptap.slo import SLOResult
 
 
 class YAMLExporter:
-    """Export request data to YAML format."""
-
-    def export(self, steps: Sequence[StepMetrics], initial_url: str, output_path: str) -> None:
+    def export(
+        self,
+        steps: Sequence[StepMetrics],
+        initial_url: str,
+        output_path: str,
+        *,
+        slo_result: SLOResult | None = None,
+    ) -> None:
         data = {
             "initial_url": initial_url,
             "total_steps": len(steps),
-            "steps": [],
+            "steps": [
+                {
+                    "url": step.url,
+                    "status": step.response.status,
+                    "timing": step.timing.to_dict(),
+                    "network": step.network.to_dict(),
+                }
+                for step in steps
+            ],
         }
-
-        for step in steps:
-            step_data = {
-                "url": step.url,
-                "status": step.response.status,
-                "timing": {
-                    "dns_ms": step.timing.dns_ms,
-                    "connect_ms": step.timing.connect_ms,
-                    "tls_ms": step.timing.tls_ms,
-                    "ttfb_ms": step.timing.ttfb_ms,
-                    "total_ms": step.timing.total_ms,
-                },
-                "network": {
-                    "ip": step.network.ip,
-                    "family": step.network.ip_family,
-                    "http_version": step.network.http_version,
-                    "tls_version": step.network.tls_version,
-                },
-            }
-            data["steps"].append(step_data)
-
+        if slo_result is not None:
+            data["slo"] = slo_result.to_dict()
         with open(output_path, "w") as f:
             yaml.dump(data, f, default_flow_style=False)
 
 
-# Usage
 from httptap import HTTPTapAnalyzer
 
 analyzer = HTTPTapAnalyzer()
 steps = analyzer.analyze_url("https://httpbin.io")
-
-exporter = YAMLExporter()
-exporter.export(steps, "https://httpbin.io", "output.yaml")
+YAMLExporter().export(steps, "https://httpbin.io", "output.yaml")
 ```
 
 ## RequestExecutor
 
-Interface for custom HTTP request execution.
+For full control over how requests are performed, implement `RequestExecutor` and pass an
+instance as `request_executor=` to `HTTPTapAnalyzer`.
 
-### Protocol Definition
+::: httptap.request_executor.RequestExecutor
 
-```python
-from typing import Protocol, runtime_checkable
-from httptap.request_executor import RequestOptions, RequestOutcome
+::: httptap.request_executor.RequestOptions
 
+::: httptap.request_executor.RequestOutcome
 
-@runtime_checkable
-class RequestExecutor(Protocol):
-    def execute(self, options: RequestOptions) -> RequestOutcome:
-        """Perform an HTTP request based on provided options."""
-        ...
-```
-
-## Type Checking
+## Type checking
 
 All protocols are fully type-hinted and work with mypy, pyright, and other type checkers.
+Because they are structural, any class implementing the required methods satisfies the type —
+no explicit subclassing needed.
 
 ```python
-from typing import reveal_type
 from httptap.interfaces import DNSResolver
 
 
 class MyResolver:
-    def resolve(self, host: str, port: int, timeout: float):
+    def resolve(self, host: str, port: int, timeout: float) -> tuple[str, str, float]:
         return "192.168.1.1", "IPv4", 10.5
 
 
-# Type checker will verify MyResolver implements the protocol
-resolver: DNSResolver = MyResolver()
-reveal_type(resolver)  # Type: DNSResolver
+resolver: DNSResolver = MyResolver()  # verified by the type checker
 ```
 
-## Next Steps
+## Next steps
 
 - See [core components documentation](core.md)
 - Review [advanced usage examples](../usage/advanced.md)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,34 +1,35 @@
+---
+title: API Overview
+description: High-level tour of the public httptap API surface exported from the package root.
+---
+
 # API Overview
 
-httptap provides a clean Python API for programmatic usage and extension. This page gives an overview of the main
-components.
+httptap provides a clean Python API for programmatic use and extension. This page maps the
+public surface exported from the `httptap` package root; the linked pages drill into the core
+classes and the extensibility protocols.
 
 ## Architecture
 
-httptap is built around a modular architecture with clear interfaces:
+httptap is built around a modular architecture with clear, injectable interfaces:
 
 ```
 ┌─────────────────┐
-│  CLI Interface  │
+│  CLI / Renderer │  wires Visualizers & Exporters
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│  HTTPTapAnalyzer│ ◄── Main entry point
+│  HTTPTapAnalyzer│  ◄── main entry point
 └────────┬────────┘
-         │
-         ├─► DNS Resolver (Protocol)
-         ├─► TLS Inspector (Protocol)
+         │  (injectable collaborators)
+         ├─► DNS Resolver     (Protocol)
+         ├─► TLS Inspector    (Protocol)
          ├─► Timing Collector (Protocol)
-         ├─► Visualizer (Protocol)
-         └─► Exporter (Protocol)
+         └─► Request Executor (Protocol)
 ```
 
-## Core Components
-
-### HTTPTapAnalyzer
-
-The main analyzer class that orchestrates HTTP request analysis.
+## Main entry point
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -52,224 +53,58 @@ steps = analyzer.analyze_url(
 )
 ```
 
-### StepMetrics
+::: httptap.analyzer.HTTPTapAnalyzer
+    options:
+      members: false
+      show_bases: false
 
-Data model representing a single request/response cycle.
+See **[Core Components](core.md)** for the full method and data-model reference.
 
-```python
-from httptap.models import StepMetrics
+## Core data model
 
-step: StepMetrics
-print(step.url)  # Request URL
-print(step.timing)  # TimingMetrics object
-print(step.network)  # NetworkInfo object
-print(step.response)  # ResponseInfo object
-```
+A single request/response cycle is captured by `StepMetrics`, which nests timing, network,
+and response detail. Full field-level docs live on the [Core Components](core.md) page.
 
-### Timing Information
+- [`StepMetrics`](core.md#httptap.models.StepMetrics) — one request in a redirect chain
+- [`TimingMetrics`](core.md#httptap.models.TimingMetrics) — phase-by-phase timing
+- [`NetworkInfo`](core.md#httptap.models.NetworkInfo) — IP, TLS, certificate, and proxy detail
+- [`ResponseInfo`](core.md#httptap.models.ResponseInfo) — status, headers, body size
 
-```python
-step.timing.dns_ms  # DNS resolution time
-step.timing.connect_ms  # TCP connection time
-step.timing.tls_ms  # TLS handshake time
-step.timing.ttfb_ms  # Time to first byte
-step.timing.total_ms  # Total request time
-step.timing.wait_ms  # Server processing time
-step.timing.xfer_ms  # Body transfer time
-step.timing.is_estimated  # Whether timing is estimated
-```
+## Protocol interfaces
 
-### Network Information
+httptap uses `Protocol` classes (PEP 544) for type-safe, inheritance-free extensibility.
+Each protocol and a worked custom implementation is documented on the
+**[Protocol Interfaces](interfaces.md)** page:
+`DNSResolver`, `TLSInspector`, `TimingCollector`, `Visualizer`, `Exporter`, and `RequestExecutor`.
 
-```python
-step.network.ip  # IP address (str | None)
-step.network.ip_family  # IPv4 or IPv6 (str | None)
-step.network.http_version  # HTTP protocol (str | None)
-step.network.tls_version  # TLS protocol version (str | None)
-step.network.tls_cipher  # Cipher suite (str | None)
-step.network.cert_cn  # Certificate common name (str | None)
-step.network.cert_days_left  # Days until expiration (int | None)
-step.network.cert_sans  # Subject Alternative Names (list[str])
-step.network.cert_issuer  # Issuer common name (str | None)
-step.network.cert_serial  # Certificate serial number (str | None)
-step.network.cert_not_before  # Validity start (datetime | None)
-step.network.cert_not_after  # Validity end (datetime | None)
-step.network.tls_verified  # Whether TLS was verified (bool | None)
-step.network.tls_custom_ca  # Custom CA bundle used (bool | None)
-```
+## Request executor
 
-### Response Data
+For fully customised HTTP behaviour, implement the `RequestExecutor` protocol and pass an
+instance as `request_executor=` to `HTTPTapAnalyzer`. The protocol contract and its
+`RequestOptions` / `RequestOutcome` data classes are documented on the
+**[Protocol Interfaces](interfaces.md#requestexecutor)** page.
 
-```python
-step.response.status  # HTTP status code (int | None)
-step.response.bytes  # Response body size (int)
-step.response.content_type  # Content-Type header (str | None)
-step.response.server  # Server header (str | None)
-step.response.date  # Response date (datetime | None)
-step.response.location  # Location header (str | None)
-step.response.headers  # All headers dict
-```
+## Built-in implementations
 
-## Protocol Interfaces
+httptap ships production-ready defaults for every protocol; all are importable from the
+package root.
 
-httptap uses Protocol classes (PEP 544) for type-safe extensibility.
+::: httptap.implementations.dns.SystemDNSResolver
 
-### DNSResolver
+::: httptap.implementations.tls.SocketTLSInspector
 
-Interface for custom DNS resolution implementations.
+::: httptap.implementations.timing.PerfCounterTimingCollector
 
-```python
-from httptap.interfaces import DNSResolver
+::: httptap.visualizer.WaterfallVisualizer
 
+::: httptap.exporter.JSONExporter
 
-class CustomResolver:
-    def resolve(self, host: str, port: int, timeout: float) -> tuple[str, str, float]:
-        """Resolve host to IP address.
+::: httptap.request_executor.HTTPClientRequestExecutor
 
-        Returns:
-            tuple[str, str, float]: (ip_address, family, duration_ms)
-        """
-        ...
-```
+## SLO evaluation
 
-### TLSInspector
-
-Interface for TLS certificate and connection inspection.
-
-```python
-from httptap.interfaces import TLSInspector
-from httptap.models import NetworkInfo
-
-
-class CustomTLSInspector:
-    def inspect(self, host: str, port: int, timeout: float) -> NetworkInfo:
-        """Inspect TLS connection and certificate.
-
-        Returns:
-            NetworkInfo with TLS version, cipher, and certificate data.
-        """
-        ...
-```
-
-### TimingCollector
-
-Interface for request timing implementations. A new instance is created for each request.
-
-```python
-from httptap.interfaces import TimingCollector
-from httptap.models import TimingMetrics
-
-
-class CustomTimingCollector:
-    def mark_dns_start(self) -> None: ...
-    def mark_dns_end(self) -> None: ...
-    def mark_request_start(self) -> None: ...
-    def mark_ttfb(self) -> None: ...
-    def mark_request_end(self) -> None: ...
-    def get_metrics(self) -> TimingMetrics: ...
-```
-
-### Visualizer
-
-Interface for custom output visualization.
-
-```python
-from httptap.interfaces import Visualizer
-from httptap.models import StepMetrics
-
-
-class CustomVisualizer:
-    def render(self, step: StepMetrics) -> None:
-        """Render a single request step for display."""
-        ...
-```
-
-### Exporter
-
-Interface for custom data export formats.
-
-```python
-from httptap.interfaces import Exporter
-from httptap.models import StepMetrics
-from collections.abc import Sequence
-
-
-class CustomExporter:
-    def export(self, steps: Sequence[StepMetrics], initial_url: str, output_path: str) -> None:
-        """Export request data to file."""
-        ...
-```
-
-## Built-in Implementations
-
-httptap provides default implementations of all protocols:
-
-### SystemDNSResolver
-
-Uses Python's `socket.getaddrinfo()` for DNS resolution.
-
-```python
-from httptap import SystemDNSResolver
-
-resolver = SystemDNSResolver()
-ip, family, duration = resolver.resolve("httpbin.io", 443, timeout=5.0)
-```
-
-### SocketTLSInspector
-
-Uses Python's `ssl` module to inspect TLS connections.
-
-```python
-from httptap import SocketTLSInspector
-
-inspector = SocketTLSInspector()
-network_info = inspector.inspect("httpbin.io", 443, 5.0)
-print(network_info.tls_version, network_info.tls_cipher)
-```
-
-### PerfCounterTimingCollector
-
-Uses `time.perf_counter()` for precise timing.
-
-```python
-from httptap import PerfCounterTimingCollector
-
-collector = PerfCounterTimingCollector()
-collector.mark_dns_start()
-# ... perform DNS ...
-collector.mark_dns_end()
-metrics = collector.get_metrics()
-```
-
-### WaterfallVisualizer
-
-Uses Rich library for waterfall terminal output.
-
-```python
-from rich.console import Console
-from httptap import WaterfallVisualizer
-
-visualizer = WaterfallVisualizer(Console())
-visualizer.render(step)
-```
-
-### JSONExporter
-
-Exports request data to JSON format.
-
-```python
-from rich.console import Console
-from httptap import JSONExporter
-
-exporter = JSONExporter(Console())
-exporter.export(steps, "https://httpbin.io", "output.json")
-```
-
-## SLO Evaluation
-
-The SLO module is exposed at the package root so programmatic callers
-can parse, evaluate, and serialize latency budgets the same way the
-CLI does.
+The SLO helpers are exposed at the package root so programmatic callers can parse, evaluate,
+and serialize latency budgets exactly as the CLI does.
 
 ```python
 from httptap import HTTPTapAnalyzer, evaluate_slo, parse_slo_spec, select_step_for_evaluation
@@ -283,63 +118,26 @@ if target is not None:
     result = evaluate_slo(target, thresholds)
     if not result.passed:
         for violation in result.violations:
-            print(
-                f"{violation.key}: {violation.actual_ms:.1f}ms "
-                f"> {violation.threshold_ms:g}ms "
-                f"(+{violation.delta_ms:.1f}ms)"
-            )
+            print(f"{violation.key}: {violation.actual_ms:.1f}ms > {violation.threshold_ms:g}ms")
 ```
 
-Key symbols (all importable from `httptap`):
+::: httptap.slo.parse_slo_spec
 
-| Symbol                        | Kind       | Purpose                                                    |
-|-------------------------------|------------|------------------------------------------------------------|
-| `SLO_KEYS`                    | frozenset  | Valid phase keys: `dns/connect/tls/ttfb/wait/xfer/total`.  |
-| `parse_slo_spec(raw)`         | function   | Parse `"total=500,ttfb=200"` → `dict[str, float]`.         |
-| `evaluate_slo(step, th)`      | function   | Run thresholds against one `StepMetrics`, return `SLOResult`. |
-| `select_step_for_evaluation(steps)` | function | Pick the final successful step of a chain.              |
-| `SLOSpecError`                | exception  | `ValueError` subclass raised on malformed specifications.  |
-| `SLOResult`                   | dataclass  | `pass`, frozen `thresholds_ms`, tuple of `violations`.     |
-| `SLOViolation`                | dataclass  | `key`, `threshold_ms`, `actual_ms`, `delta_ms`.            |
+::: httptap.slo.evaluate_slo
 
-`SLOResult` is a frozen dataclass; both `thresholds_ms` (read-only
-mapping view) and `violations` (tuple) are immutable. `SLOResult.to_dict()`
-produces the same structure as the `summary.slo` key in the JSON
-export.
+::: httptap.slo.select_step_for_evaluation
 
-## Request Executor
+::: httptap.slo.SLOResult
 
-For fully customized HTTP behavior, implement the `RequestExecutor` protocol.
+::: httptap.slo.SLOViolation
 
-```python
-from httptap import RequestExecutor, RequestOptions, RequestOutcome
+::: httptap.slo.SLOSpecError
 
+::: httptap.slo.SLO_KEYS
 
-class CustomExecutor:
-    def execute(self, options: RequestOptions) -> RequestOutcome:
-        """Perform an HTTP request based on provided options."""
-        ...
-```
+## Error handling
 
-## Type Hints
-
-All public APIs are fully type-hinted for excellent IDE support.
-
-```python
-from httptap import HTTPTapAnalyzer
-from httptap.models import StepMetrics
-
-
-def analyze_api(url: str) -> list[StepMetrics]:
-    """Analyze API endpoint and return steps."""
-    analyzer: HTTPTapAnalyzer = HTTPTapAnalyzer()
-    steps: list[StepMetrics] = analyzer.analyze_url(url)
-    return steps
-```
-
-## Error Handling
-
-httptap returns errors as part of `StepMetrics` rather than raising exceptions during analysis.
+httptap returns errors as part of `StepMetrics` rather than raising during analysis.
 
 ```python
 from httptap import HTTPTapAnalyzer

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,3 +1,7 @@
+---
+description: How to set up a development environment and contribute code, tests, and docs to httptap.
+---
+
 # Contributing
 
 We welcome contributions to httptap! This guide will help you get started.
@@ -292,6 +296,7 @@ docs/
 Build docs locally:
 
 ```bash
+uv sync --group docs
 uv run mkdocs serve
 ```
 

--- a/docs/development/contributing.zh.md
+++ b/docs/development/contributing.zh.md
@@ -1,0 +1,345 @@
+---
+description: 如何搭建开发环境，并为 httptap 贡献代码、测试和文档。
+---
+
+# 贡献指南
+
+我们欢迎对 httptap 的贡献！本指南将帮助你上手。
+
+## 行为准则
+
+请注意，本项目遵循 [Contributor Covenant 行为准则](https://github.com/ozeranskii/httptap/blob/main/CODE_OF_CONDUCT.md)。参与本项目即表示你应当维护此准则。
+
+## 开始
+
+### 前置条件
+
+- Python 3.10 或更高版本（CPython）
+- [uv](https://github.com/astral-sh/uv) 包管理器
+- Git
+
+### 搭建开发环境
+
+1. **Fork 并克隆仓库：**
+
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/httptap.git
+   cd httptap
+   ```
+
+2. **安装依赖：**
+
+   ```bash
+   uv sync
+   ```
+
+3. **验证安装：**
+
+   ```bash
+   uv run httptap --version
+   ```
+
+## 开发工作流
+
+### 运行测试
+
+运行完整测试套件：
+
+```bash
+uv run pytest
+```
+
+带覆盖率运行：
+
+```bash
+uv run pytest --cov --cov-report=html
+```
+
+查看覆盖率报告：
+
+```bash
+open htmlcov/index.html  # macOS
+xdg-open htmlcov/index.html  # Linux
+```
+
+### 代码质量
+
+#### 代码检查（Linting）
+
+运行 Ruff linter：
+
+```bash
+uv run ruff check
+```
+
+自动修复问题：
+
+```bash
+uv run ruff check --fix
+```
+
+#### 格式化
+
+检查格式：
+
+```bash
+uv run ruff format --check
+```
+
+自动格式化代码：
+
+```bash
+uv run ruff format .
+```
+
+#### 类型检查
+
+运行 mypy：
+
+```bash
+uv run mypy httptap
+```
+
+### 运行基准测试
+
+性能基准测试使用 [pytest-codspeed](https://codspeed.io)，并在 CI 中自动运行：
+
+```bash
+# 在本地运行基准测试（验证正确性，不产生性能数据）
+uv run pytest tests/test_benchmarks.py --codspeed
+
+# 在本地测量墙钟时间，并输出结果表
+uv run pytest tests/test_benchmarks.py --codspeed --codspeed-mode=walltime
+
+# 不使用 CodSpeed 运行基准测试（作为普通测试）
+uv run pytest tests/test_benchmarks.py
+```
+
+基准测试覆盖 models、formatters、utils 和 exporter 模块中的纯计算函数。CI 会测量 CPU 指令数（`simulation`）和内存分配（`memory`）。
+
+使用 `--codspeed-mode=walltime` 可在本地检查某项优化而无需等待 CI；每个基准大约耗时两秒。墙钟数值在共享硬件上本质上是有噪声的，因此 CI 转而依赖 `simulation`——请将本地的墙钟结果视为方向性信号，而非 CI 将报告的数值。
+
+### 在本地运行
+
+测试你的更改：
+
+```bash
+uv run httptap https://httpbin.io
+```
+
+或以可编辑模式安装：
+
+```bash
+uv pip install -e .
+httptap https://httpbin.io
+```
+
+## 进行更改
+
+### 分支命名
+
+使用具有描述性的分支名称：
+
+- `feature/add-http2-support` - 新功能
+- `fix/tls-timeout-issue` - 缺陷修复
+- `docs/update-api-reference` - 文档
+- `refactor/extract-parser` - 代码重构
+
+### 提交信息
+
+遵循 conventional commits 格式：
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**类型（Types）：**
+
+- `feat` - 新功能
+- `fix` - 缺陷修复
+- `docs` - 文档更改
+- `refactor` - 代码重构
+- `test` - 添加/更新测试
+- `chore` - 维护任务
+- `perf` - 性能改进
+
+**示例：**
+
+```
+feat(cli): add --timeout flag for request timeout
+
+Add command-line option to specify custom timeout for HTTP requests.
+Defaults to 20 seconds if not specified.
+
+Closes #123
+```
+
+```
+fix(tls): handle certificate expiry edge case
+
+Fix crash when certificate expiry date is in the past.
+Now properly reports negative days and warns user.
+
+Fixes #456
+```
+
+### 代码风格
+
+遵循 [Google Python 风格指南](https://google.github.io/styleguide/pyguide.html)：
+
+- 为所有函数签名使用类型提示
+- 为所有公共 API 编写文档字符串
+- 保持每行不超过 120 个字符
+- 字符串使用双引号
+- 遵循 PEP 8 命名约定
+
+**示例：**
+
+```python
+def resolve_hostname(host: str, timeout: float = 5.0) -> tuple[str, str]:
+    """Resolve hostname to IP address.
+
+    Args:
+        host: Hostname to resolve.
+        timeout: Maximum time to wait in seconds.
+
+    Returns:
+        Tuple of (ip_address, family).
+
+    Raises:
+        DNSError: If resolution fails.
+    """
+    pass
+```
+
+### 测试指引
+
+- 为所有新功能编写测试
+- 维持或提升代码覆盖率
+- 使用具有描述性的测试名称
+- Mock 外部依赖（DNS、TLS、HTTP）
+- 同时测试成功和失败的情形
+
+**示例：**
+
+```python
+def test_analyzer_follows_redirects(mock_http_client):
+    """Test that analyzer follows redirect chains correctly."""
+    analyzer = HTTPTapAnalyzer(follow_redirects=True)
+    steps = analyzer.analyze_url("https://httpbin.io/redirect/3")
+
+    assert len(steps) == 4  # Initial + 3 redirects
+    assert steps[-1].response.status == 200
+```
+
+## Pull Request 流程
+
+1. **创建功能分支：**
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **进行更改并提交：**
+
+   ```bash
+   git add .
+   git commit -m "feat: add awesome feature"
+   ```
+
+3. **推送到你的 fork：**
+
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+4. **创建 Pull Request：**
+
+    - 前往 [httptap 仓库](https://github.com/ozeranskii/httptap)
+    - 点击 “New Pull Request”
+    - 选择你的分支
+    - 填写 PR 模板
+
+### PR 检查清单
+
+在提交之前，请确保：
+
+- [ ] 测试通过（`uv run pytest`）
+- [ ] 代码已格式化（`uv run ruff format .`）
+- [ ] Linter 通过（`uv run ruff check`）
+- [ ] 类型检查通过（`uv run mypy httptap`）
+- [ ] 文档已更新（如有需要）
+- [ ] CHANGELOG.md 已更新（针对重要更改）
+- [ ] 提交信息遵循 conventional 格式
+
+## 文档
+
+### 更新文档
+
+文档位于 `docs/` 目录：
+
+```
+docs/
+├── getting-started/
+├── usage/
+├── api/
+├── development/
+└── about/
+```
+
+在本地构建文档：
+
+```bash
+uv sync --group docs
+uv run mkdocs serve
+```
+
+访问：http://127.0.0.1:8000
+
+### 文档规范
+
+- 使用清晰、简洁的语言
+- 包含代码示例
+- 保持示例真实且实用
+- 使用正确的 Markdown 格式
+- 测试所有代码示例
+
+## 可贡献的方向
+
+### 适合新手的 Issue
+
+寻找标记为 [`good first issue`](https://github.com/ozeranskii/httptap/labels/good%20first%20issue) 的 issue——这些对新手友好。
+
+### 需要帮助
+
+标记为 [`help wanted`](https://github.com/ozeranskii/httptap/labels/help%20wanted) 的 issue 是我们非常希望获得协助的优先事项。
+
+### 贡献创意
+
+- **HTTP/3 支持** - 扩展到最新的协议版本
+- **更多导出格式** - CSV、XML、Prometheus 指标
+- **额外的可视化** - 火焰图、图表
+- **性能优化** - 更快的 DNS、连接池
+- **更多 TLS 细节** - OCSP、证书链分析
+- **自定义报告器** - Slack、webhook 通知
+- **额外的协议** - WebSocket、gRPC 计时
+
+## 获取帮助
+
+- **GitHub Issues** - 缺陷报告和功能请求
+- **Discussions** - 提问与一般性讨论
+- **Discord** - 实时聊天（即将推出）
+
+## 致谢
+
+贡献者会在以下位置得到认可：
+
+- [CHANGELOG.md](https://github.com/ozeranskii/httptap/blob/main/CHANGELOG.md)
+- GitHub 贡献者页面
+- 发布说明
+
+感谢你为 httptap 做出贡献！🎉

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -1,3 +1,7 @@
+---
+description: The automated GitHub Actions release process for httptap, plus manual release steps.
+---
+
 # Release Process
 
 This document describes the automated release process for httptap.
@@ -77,22 +81,22 @@ The release process is triggered manually via GitHub Actions.
    uv build  # Create wheel and sdist
    ```
 
-5. **Publish to TestPyPI**
+6. **Publish to TestPyPI**
     - Uploads to TestPyPI first via OIDC Trusted Publishing, with PEP 740
       attestations, as a smoke test before the production push.
 
-6. **Publish to PyPI**
+7. **Publish to PyPI**
     - Uses OIDC Trusted Publishing (no tokens required)
     - Uploads wheel and source distribution with PEP 740 attestations
 
-7. **Publish container image to GHCR**
+8. **Publish container image to GHCR**
     - Builds multi-arch (linux/amd64, linux/arm64) image
     - Pushes to `ghcr.io/ozeranskii/httptap` with `{version}`, `{major}.{minor}`,
       `{major}`, and `latest` tags
     - Signs the image with cosign (keyless Sigstore)
     - Attaches SLSA build provenance via `actions/attest-build-provenance`
 
-8. **GitHub Release**
+9. **GitHub Release**
     - Creates release with generated notes
     - Attaches build artifacts, SBOMs, VEX, and the man page
 
@@ -244,7 +248,7 @@ uv build
 uv publish  # Requires PyPI credentials
 ```
 
-### 7. Create GitHub Release
+### 8. Create GitHub Release
 
 Use `gh` CLI or web interface to create release with changelog notes.
 
@@ -289,7 +293,7 @@ After successful release:
 1. Verify package on PyPI: https://pypi.org/project/httptap/
 2. Check GitHub release: https://github.com/ozeranskii/httptap/releases
 3. Test installation: `uv pip install httptap=={version}`
-4. Announce release (Twitter, Discord, etc.)
+4. Announce release (e.g. GitHub Discussions, Telegram)
 
 ## Release Checklist
 

--- a/docs/development/release.zh.md
+++ b/docs/development/release.zh.md
@@ -1,0 +1,315 @@
+---
+description: httptap 基于 GitHub Actions 的自动化发布流程，以及手动发布步骤。
+---
+
+# 发布流程
+
+本文档描述 httptap 的自动化发布流程。
+
+## 概述
+
+发布完全通过 GitHub Actions 实现自动化。该工作流负责版本管理、变更日志生成、测试、
+构建、签名、发布到 TestPyPI 和 PyPI，并将一个
+已签名的容器镜像推送到 GHCR。
+
+## 前置条件
+
+在创建发布之前，请确保：
+
+1. **GitHub Environments** —— 在仓库设置中已配置 `release`、`testpypi` 和 `pypi` 环境
+2. **PyPI Trusted Publishing** —— 已为 PyPI 和 TestPyPI 配置（OIDC，无需令牌）
+3. **Deploy Key** —— 具有写入权限的 SSH deploy key（用于绕过分支保护）
+4. **GHCR access** —— release 任务上的 `packages: write` 权限（按工作流授予）
+5. **所有测试通过** —— main 分支上的 CI 必须为绿色
+
+## 发布工作流
+
+发布流程通过 GitHub Actions 手动触发。
+
+### 触发一次发布
+
+1. 前往 **Actions** → **Release** 工作流
+2. 点击 **Run workflow**
+3. 选择版本策略：
+    - **显式版本**：输入确切版本号（例如 `0.3.0`）
+    - **语义化递增**：选择 `patch`、`minor` 或 `major`
+
+### 语义化版本控制
+
+| 递增类型 | 示例          | 使用场景                           |
+|-----------|---------------|------------------------------------|
+| `patch`   | 0.1.0 → 0.1.1 | 缺陷修复、小幅改进                  |
+| `minor`   | 0.1.0 → 0.2.0 | 新功能，向后兼容                    |
+| `major`   | 0.1.0 → 1.0.0 | 破坏性变更                          |
+
+### 自动执行的操作
+
+1. **版本更新**
+   ```bash
+   uv version 0.2.0  # or
+   uv version --bump minor
+   ```
+   更新 `pyproject.toml` 中的 `version`
+
+2. **锁文件刷新**
+   ```bash
+   uv lock
+   ```
+   重新生成 `uv.lock`，使其与新版本保持同步
+
+3. **变更日志生成**
+   ```bash
+   git cliff --tag v0.2.0 --unreleased --prepend CHANGELOG.md
+   ```
+   基于约定式提交生成变更日志
+
+4. **已签名的提交与标签**
+   ```bash
+   git commit -S -m "chore: release v0.2.0"
+   git tag -s v0.2.0 -m "Release v0.2.0"
+   git push origin HEAD
+   git push origin v0.2.0
+   ```
+   通过 [gitsign](https://github.com/sigstore/gitsign) 进行无密钥 Sigstore 签名：
+   短生命周期的 Fulcio 证书通过工作流的 OIDC
+   身份签发，因此无需长期保存的 GPG 密钥。
+
+5. **构建**
+   ```bash
+   uv sync --locked --group test
+   uv run pytest  # Full test suite
+   uv build  # Create wheel and sdist
+   ```
+
+6. **发布到 TestPyPI**
+    - 先通过 OIDC Trusted Publishing 上传到 TestPyPI，附带 PEP 740
+      证明，作为投产推送前的冒烟测试。
+
+7. **发布到 PyPI**
+    - 使用 OIDC Trusted Publishing（无需令牌）
+    - 上传 wheel 和源码分发包，附带 PEP 740 证明
+
+8. **发布容器镜像到 GHCR**
+    - 构建多架构（linux/amd64、linux/arm64）镜像
+    - 推送到 `ghcr.io/ozeranskii/httptap`，带有 `{version}`、`{major}.{minor}`、
+      `{major}` 和 `latest` 标签
+    - 使用 cosign（无密钥 Sigstore）对镜像签名
+    - 通过 `actions/attest-build-provenance` 附加 SLSA 构建来源证明
+
+9. **GitHub Release**
+    - 创建带有生成的发布说明的 release
+    - 附上构建产物、SBOM、VEX 和 man 手册页
+
+## 工作流配置
+
+发布工作流定义于 `.github/workflows/release.yml`：
+
+### 关键任务
+
+#### 1. 准备发布
+
+- 使用 deploy key 检出代码
+- 配置 Python 和 uv
+- 更新 pyproject.toml 中的版本
+- 生成变更日志
+- 提交并推送更改
+- 创建并推送 git 标签
+
+#### 2. 构建软件包
+
+- 检出已打标签的版本
+- 运行完整测试套件
+- 构建 wheel 和 sdist
+- 通过 [Syft](https://github.com/anchore/syft) 以 CycloneDX 和 SPDX JSON 格式生成 SBOM
+- 将带版本号的 OpenVEX 文档从 `.vex/httptap.openvex.json` 复制到 `sbom/` 目录，命名为 `httptap-X.Y.Z.openvex.json`
+- 使用 [argparse-manpage](https://github.com/praiskup/argparse-manpage) 生成经过 gzip 压缩的 `man(1)` 手册页
+- 分别上传 `dist/`、`sbom/` 和 `man/` 产物
+
+#### 3. 发布到 TestPyPI
+
+- 下载 `dist/` 产物
+- 通过 TestPyPI OIDC Trusted Publishing 发布，附带 PEP 740 证明
+
+#### 4. 发布到 PyPI
+
+- 仅在 TestPyPI 成功后运行
+- 使用 Trusted Publishing 发布，附带 PEP 740 证明
+
+#### 5. 发布容器镜像到 GHCR
+
+- 使用 Buildx + QEMU 构建多架构镜像
+- 使用 cosign（无密钥 Sigstore OIDC）签名
+- 附加 SLSA 构建来源证明
+
+#### 6. 创建 GitHub Release
+
+- 下载 `dist/`、`sbom/` 和 `man/` 产物
+- 创建带有变更日志说明的 GitHub release
+- 附上 wheel、sdist、SBOM（`*.cdx.json`、`*.spdx.json`）、VEX（`*.openvex.json`）和 man 手册页
+
+## 变更日志生成
+
+变更日志基于约定式提交，使用 [git-cliff](https://git-cliff.org/) 自动生成。
+
+### 提交格式
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### 支持的类型
+
+| 类型       | 变更日志分区      | 示例                                     |
+|------------|-------------------|------------------------------------------|
+| `feat`     | Features          | `feat(cli): add --timeout flag`          |
+| `fix`      | Bug Fixes         | `fix(tls): handle expired certificates`  |
+| `perf`     | Performance       | `perf(dns): optimize resolver cache`     |
+| `docs`     | Documentation     | `docs: update API reference`             |
+| `refactor` | Refactor          | `refactor(core): extract analyzer logic` |
+| `test`     | Testing           | `test: add integration tests`            |
+| `chore`    | Miscellaneous     | `chore: update dependencies`             |
+
+### 破坏性变更
+
+在提交页脚中标记破坏性变更：
+
+```
+feat(api): redesign analyzer interface
+
+BREAKING CHANGE: HTTPTapAnalyzer constructor signature changed
+```
+
+## 版本策略
+
+httptap 遵循 [语义化版本控制](https://semver.org/)：
+
+- **主版本号**（1.0.0）—— 破坏性变更
+- **次版本号**（0.1.0）—— 新功能，向后兼容
+- **修订版本号**（0.0.1）—— 缺陷修复
+
+### 1.0 之前的开发
+
+在 1.0 之前的开发阶段（0.x.x）：
+
+- 次版本号可能包含破坏性变更
+- 修订版本号用于缺陷修复和小功能
+- 当 API 稳定后升级到 1.0.0
+
+## 手动发布步骤
+
+如果你需要手动发布（不推荐）：
+
+### 1. 更新版本
+
+```bash
+uv version 0.2.0
+```
+
+### 2. 重新生成锁文件
+
+```bash
+uv lock
+```
+
+### 3. 生成变更日志
+
+```bash
+git cliff --tag v0.2.0 --unreleased --prepend CHANGELOG.md
+```
+
+### 4. 提交更改
+
+```bash
+git add pyproject.toml uv.lock CHANGELOG.md
+git commit -m "chore: release v0.2.0"
+```
+
+### 5. 创建标签
+
+```bash
+git tag -a v0.2.0 -m "Release v0.2.0"
+```
+
+### 6. 推送
+
+```bash
+git push origin main
+git push origin v0.2.0
+```
+
+### 7. 构建并发布
+
+```bash
+uv build
+uv publish  # Requires PyPI credentials
+```
+
+### 8. 创建 GitHub Release
+
+使用 `gh` CLI 或网页界面创建带有变更日志说明的 release。
+
+## 故障排查
+
+### 分支保护错误
+
+如果因分支保护导致推送失败：
+
+1. 验证 deploy key 具有写入权限
+2. 检查 deploy key 是否在分支保护规则的绕过列表中
+3. 确保工作流检出中已配置 `ssh-key`
+
+### 变更日志为空
+
+如果变更日志生成返回为空：
+
+1. 确保提交遵循约定式格式
+2. 检查 `.release/git-cliff.toml` 中的 git-cliff 配置
+3. 验证标签尚不存在
+
+### PyPI 发布失败
+
+如果 PyPI 发布失败：
+
+1. 验证 `pypi` 环境是否存在
+2. 检查 PyPI 上是否已配置 Trusted Publishing
+3. 确保工作流具有 `id-token: write` 权限
+
+### 测试失败
+
+如果发布期间测试失败：
+
+1. 工作流会在发布前停止
+2. 修复问题并重新运行工作流
+3. 不会发生部分发布
+
+## 发布之后
+
+发布成功之后：
+
+1. 在 PyPI 上验证软件包：https://pypi.org/project/httptap/
+2. 检查 GitHub release：https://github.com/ozeranskii/httptap/releases
+3. 测试安装：`uv pip install httptap=={version}`
+4. 宣布发布（例如 GitHub Discussions、Telegram）
+
+## 发布检查清单
+
+在触发发布之前：
+
+- [ ] main 上所有 CI 检查通过
+- [ ] 没有已知的严重缺陷
+- [ ] 文档已更新
+- [ ] 破坏性变更已记录
+- [ ] 迁移指南已编写（针对主版本）
+- [ ] 依赖已更新
+- [ ] 安全漏洞已处理
+
+## 另见
+
+- [约定式提交](https://www.conventionalcommits.org/)
+- [语义化版本控制](https://semver.org/)
+- [git-cliff 文档](https://git-cliff.org/)
+- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,10 +1,14 @@
+---
+description: Install httptap with uvx, Homebrew, PyPI, a container, or from source, and enable shell completion.
+---
+
 # Installation
 
 ## Requirements
 
 Before installing httptap, ensure you have:
 
-- **Python 3.10 or higher** (CPython recommended)
+- **Python 3.10-3.15** (CPython recommended)
 - **pip** or **uv** package manager
 - **macOS, Linux, or Windows** operating system
 
@@ -35,12 +39,12 @@ uvx --from "httptap[completion]" httptap https://example.com
     brew install httptap
     ```
 
-!!! tip "Recommended for macOS/Linux users"
+!!! tip "Convenient for macOS/Linux users"
     Homebrew installation is the simplest method and includes automatic shell completion setup.
 
 ## Installing from PyPI
 
-=== "Using uv (recommended)"
+=== "Using uv"
 
     ```bash
     uv pip install httptap
@@ -82,7 +86,7 @@ cosign verify ghcr.io/ozeranskii/httptap:latest \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-Pinned major/minor tags (e.g. `:0`, `:0.5`, `:0.5.0`) are also published.
+Pinned major/minor tags (e.g. `:0`, `:0.6`, `:0.6.0`) are also published.
 
 ## Installing from Source
 
@@ -97,7 +101,6 @@ cd httptap
 
 ```bash
 uv sync
-uv pip install -e .
 ```
 
 ### Install with pip
@@ -225,10 +228,16 @@ If you installed httptap via `pip`, `uv`, or `pipx`, you need to install the opt
     source .venv/bin/activate
     ```
 
-2. Run the global activation script:
+2. Enable completion for bash/zsh. Either register it globally once:
 
     ```bash
     activate-global-python-argcomplete
+    ```
+
+    Or, to enable it only for `httptap`, add this to your shell startup file (e.g. `~/.bashrc` or `~/.zshrc`):
+
+    ```bash
+    eval "$(register-python-argcomplete httptap)"
     ```
 
 3. Restart your shell.

--- a/docs/getting-started/installation.zh.md
+++ b/docs/getting-started/installation.zh.md
@@ -1,0 +1,289 @@
+---
+description: 使用 uvx、Homebrew、PyPI、容器或源码安装 httptap，并启用 shell 自动补全。
+---
+
+# 安装
+
+## 环境要求
+
+在安装 httptap 之前，请确保你具备：
+
+- **Python 3.10-3.15**（推荐 CPython）
+- **pip** 或 **uv** 包管理器
+- **macOS、Linux 或 Windows** 操作系统
+
+除标准网络能力外，无需任何系统依赖。
+
+## 使用 uvx 运行
+
+无需永久安装即可运行 httptap 的最快方式。[`uvx`](https://docs.astral.sh/uv/guides/tools/)（随 [uv](https://docs.astral.sh/uv/) 一同提供）会获取 httptap 并在一个临时的、隔离的环境中运行它：
+
+```bash
+uvx --from "httptap[completion]" httptap https://example.com
+```
+
+!!! tip "推荐用于快速试用"
+    `uvx` 无需任何预先的安装步骤，且不会留下任何残留——非常适合一次性检查或试用 httptap。若需反复使用，请用下列方法之一进行安装。
+
+## 通过 Homebrew 安装
+
+=== "macOS"
+
+    ```bash
+    brew install httptap
+    ```
+
+=== "Linux"
+
+    ```bash
+    brew install httptap
+    ```
+
+!!! tip "适合 macOS/Linux 用户"
+    Homebrew 安装是最简单的方法，并包含自动的 shell 自动补全设置。
+
+## 从 PyPI 安装
+
+=== "使用 uv"
+
+    ```bash
+    uv pip install httptap
+    ```
+
+    或作为全局工具安装：
+
+    ```bash
+    uv tool install httptap
+    ```
+
+=== "使用 pip"
+
+    ```bash
+    pip install httptap
+    ```
+
+=== "使用 pipx"
+
+    用于隔离式的 CLI 工具安装：
+
+    ```bash
+    pipx install httptap
+    ```
+
+## 通过容器运行
+
+已签名的多架构（linux/amd64、linux/arm64）镜像会在每次发布时发布到 GitHub Container Registry：
+
+```bash
+docker run --rm ghcr.io/ozeranskii/httptap:latest https://example.com
+```
+
+使用 [cosign](https://docs.sigstore.dev/cosign/overview/)（无密钥 Sigstore）校验镜像签名：
+
+```bash
+cosign verify ghcr.io/ozeranskii/httptap:latest \
+  --certificate-identity-regexp 'https://github\.com/ozeranskii/httptap/\.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+固定的主/次版本标签（例如 `:0`、`:0.6`、`:0.6.0`）也会一并发布。
+
+## 从源码安装
+
+### 克隆仓库
+
+```bash
+git clone https://github.com/ozeranskii/httptap.git
+cd httptap
+```
+
+### 使用 uv 安装
+
+```bash
+uv sync
+```
+
+### 使用 pip 安装
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+pip install -e .
+```
+
+## 验证安装
+
+安装完成后，验证 httptap 是否正确安装：
+
+```bash
+httptap --version
+```
+
+你应该会看到类似如下的输出：
+
+```
+httptap X.Y.Z
+```
+
+## 升级
+
+将 httptap 升级到最新版本：
+
+=== "使用 Homebrew"
+
+    ```bash
+    brew upgrade httptap
+    ```
+
+=== "使用 uv"
+
+    ```bash
+    uv pip install --upgrade httptap
+    ```
+
+=== "使用 pip"
+
+    ```bash
+    pip install --upgrade httptap
+    ```
+
+## 卸载
+
+从系统中移除 httptap：
+
+=== "使用 Homebrew"
+
+    ```bash
+    brew uninstall httptap
+    ```
+
+=== "使用 uv"
+
+    ```bash
+    uv pip uninstall httptap
+    ```
+
+=== "使用 pip"
+
+    ```bash
+    pip uninstall httptap
+    ```
+
+=== "使用 pipx"
+
+    ```bash
+    pipx uninstall httptap
+    ```
+
+---
+
+## Shell 自动补全
+
+httptap 支持 bash 和 zsh 的 shell 自动补全。
+
+### Homebrew 安装
+
+如果你通过 Homebrew 安装了 httptap，**补全会自动配置好**。只需重启你的 shell：
+
+```bash
+# Restart your shell
+exec $SHELL
+```
+
+Homebrew 会自动将补全脚本放置到：
+
+- **Bash**：`$(brew --prefix)/etc/bash_completion.d/`
+- **Zsh**：`$(brew --prefix)/share/zsh/site-functions/`
+
+!!! success "无需额外设置"
+    Homebrew 会自动处理所有补全设置。只需重启你的 shell，即可开始使用 Tab 补全！
+
+### Python 包安装
+
+如果你通过 `pip`、`uv` 或 `pipx` 安装了 httptap，则需要安装可选的 `completion` 附加项：
+
+=== "使用 uv"
+
+    ```bash
+    uv pip install "httptap[completion]"
+    ```
+
+=== "使用 pip"
+
+    ```bash
+    pip install "httptap[completion]"
+    ```
+
+=== "使用 pipx"
+
+    ```bash
+    pipx install "httptap[completion]"
+    ```
+
+#### 激活
+
+1. 激活你的虚拟环境（如果使用 venv）：
+
+    ```bash
+    source .venv/bin/activate
+    ```
+
+2. 为 bash/zsh 启用补全。可以一次性进行全局注册：
+
+    ```bash
+    activate-global-python-argcomplete
+    ```
+
+    或者，若只想为 `httptap` 启用补全，请将下面这行加入你的 shell 启动文件（例如 `~/.bashrc` 或 `~/.zshrc`）：
+
+    ```bash
+    eval "$(register-python-argcomplete httptap)"
+    ```
+
+3. 重启你的 shell。
+
+### 用法
+
+安装并激活后，你可以使用 `Tab` 来自动补全命令和选项：
+
+```bash
+# Complete command options
+httptap --<TAB>
+
+# Complete after typing partial option
+httptap --fol<TAB>
+# Completes to: httptap --follow
+
+# Complete multiple options
+httptap --follow --time<TAB>
+# Completes to: httptap --follow --timeout
+```
+
+!!! note
+    全局激活脚本仅为 bash 和 zsh 提供参数补全。其他 shell 不在该脚本覆盖范围内，需单独配置。
+
+---
+
+## 下一步？
+
+<div class="grid cards" markdown>
+
+-   :material-lightning-bolt:{ .lg .middle } **[快速开始指南](quick-start.md)**
+
+    ---
+
+    通过简单示例学习基础用法
+
+-   :material-console:{ .lg .middle } **[基础用法](../usage/basic.md)**
+
+    ---
+
+    完整的命令行参考
+
+-   :material-api:{ .lg .middle } **[API 参考](../api/overview.md)**
+
+    ---
+
+    以编程方式使用 httptap
+
+</div>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,3 +1,7 @@
+---
+description: Get started with httptap through basic requests and common command-line examples.
+---
+
 # Quick Start
 
 This guide will walk you through the basic usage of httptap.

--- a/docs/getting-started/quick-start.zh.md
+++ b/docs/getting-started/quick-start.zh.md
@@ -1,0 +1,273 @@
+---
+description: 通过基础请求和常见命令行示例快速上手 httptap。
+---
+
+# 快速开始
+
+本指南将带你了解 httptap 的基础用法。
+
+## 基础请求
+
+发起一次简单的 HTTP 请求并显示丰富的瀑布图视图：
+
+```bash
+httptap https://httpbin.io
+```
+
+这会输出一份详细的计时分解，展示：
+
+- DNS 解析时间
+- TCP 连接建立
+- TLS 握手（针对 HTTPS）
+- 首字节时间 (TTFB)
+- 响应体传输时间
+
+## 发起 POST 请求
+
+向 API 发送 JSON 数据：
+
+```bash
+httptap --data '{"name": "John Doe", "email": "john@example.com"}' https://httpbin.io/post
+```
+
+!!! tip "自动 POST 行为"
+    当提供了 `--data` 而未提供 `--method` 时，httptap 会自动切换为 POST（类似 curl）。
+
+!!! tip "兼容 curl 的参数"
+    最常见的 curl 参数可原样使用。使用 `-X/--request` 指定 HTTP 方法，`-L/--location` 跟随重定向，`-m/--max-time` 设置超时，`-k/--insecure` 禁用证书校验，`-x` 指定代理，`--http1.1` 强制使用 HTTP/1.1（等价于 `--no-http2`）。并非所有 curl 选项都受支持，因此替换命令时请只使用这些共有参数。
+
+从文件加载数据：
+
+```bash
+echo '{"title": "New Post", "content": "Hello World"}' > post-data.json
+httptap --data @post-data.json https://httpbin.io/post
+```
+
+## 使用其他 HTTP 方法
+
+httptap 支持所有标准 HTTP 方法：
+
+**PUT 请求：**
+```bash
+httptap --method PUT --data '{"status": "updated"}' https://httpbin.io/put
+```
+
+**PATCH 请求：**
+```bash
+httptap --method PATCH --data '{"field": "value"}' https://httpbin.io/patch
+```
+
+**DELETE 请求：**
+```bash
+httptap --method DELETE https://httpbin.io/delete
+```
+
+**HEAD 请求（仅请求头）：**
+```bash
+httptap --method HEAD https://httpbin.io/get
+```
+
+## 添加自定义请求头
+
+使用 `-H` 参数添加自定义 HTTP 请求头：
+
+```bash
+httptap -H "Accept: application/json" https://httpbin.io/json
+```
+
+可通过重复该参数添加多个请求头：
+
+```bash
+httptap \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  https://httpbin.io/bearer
+```
+
+## 跟随重定向
+
+默认情况下，httptap 不会跟随重定向。若要跟随重定向链：
+
+```bash
+httptap --follow https://httpbin.io/redirect/3
+```
+
+这会展示重定向链中每一步的计时信息。
+
+## 紧凑输出
+
+若希望每一步以人类可读的单行呈现——适合终端日志以及通过 `grep` / `tee` 进行 tail：
+
+```bash
+httptap --compact https://httpbin.io/get
+```
+
+输出示例：
+
+```
+Step 1: 200 GET https://httpbin.io/get | dns=8.9ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=447.3ms | 389 B
+```
+
+该行以 HTTP 状态开头，因此失败会格外醒目；计时会带 `ms` 后缀，响应大小则以合适的单位（`B`、`KB`、`MB`）渲染。重定向链仍会以完整的 `Redirect Chain Summary` 表格结尾，从而保持请求的整体形态可见。
+
+若需要机器可解析的 `key=value` 输出（无单位，含 IP/地址族/TLS 字段），请使用下文的 `--metrics-only`。
+
+## 仅指标模式
+
+获取无格式的原始指标，非常适合脚本使用：
+
+```bash
+httptap --metrics-only https://httpbin.io
+```
+
+输出示例：
+
+```
+Step 1: dns=30.1 connect=97.3 tls=199.0 ttfb=472.2 total=476.0 status=200 bytes=389 ip=44.211.11.205 family=IPv4 tls_version=TLSv1.2 proxy=direct
+```
+
+## JSON 导出
+
+将完整的请求数据导出为 JSON 以便后续分析：
+
+```bash
+httptap --json output.json https://httpbin.io
+```
+
+该 JSON 文件将包含：
+
+- 所有阶段的详细计时
+- 网络信息（IP、TLS 版本、证书详情）
+- 响应元数据（状态、请求头、响应体大小）
+- 完整的重定向链（如果使用了 `--follow`）
+- SLO 评估（如果提供了 `--slo`）
+
+## SLO 阈值校验
+
+使用 `--slo` 基于各阶段延迟预算为 CI 任务、cron 探针或 Kubernetes 就绪检查设置门禁：
+
+```bash
+httptap --slo total=500,ttfb=200 https://httpbin.io/get
+```
+
+当每个预算都通过时退出码为 `0`，当任一阈值被违反时退出码为 `4`。完整的瀑布图仍会被渲染，以便你看清校验*为何*失败。
+
+!!! tip "支持的 SLO 键"
+    `dns`、`connect`、`tls`、`ttfb`、`wait`、`xfer`、`total`——每一个都映射到一个计时阶段。完整规范与实用示例请参见专门的 [SLO 阈值校验](../usage/slo.md) 页面。
+
+## 常见用例
+
+### API 测试
+
+测试一个完整的 REST API 工作流：
+
+```bash
+# Create a resource
+httptap --data '{"title": "Test Post"}' https://httpbin.io/post
+
+# Update the resource
+httptap --method PUT --data '{"title": "Updated Post"}' https://httpbin.io/put
+
+# Partial update
+httptap --method PATCH --data '{"published": true}' https://httpbin.io/patch
+
+# Delete the resource
+httptap --method DELETE https://httpbin.io/delete
+```
+
+### 检查 API 延迟
+
+```bash
+httptap --compact https://httpbin.io/status/200
+```
+
+### 调试慢速响应
+
+```bash
+httptap https://httpbin.io/delay/3
+```
+
+瀑布图视图将帮助识别是哪个阶段导致了延迟（DNS、连接、TLS 或服务器处理）。
+
+### 验证 TLS 配置
+
+```bash
+httptap https://httpbin.io
+```
+
+在输出中查看 TLS 版本、加密套件以及证书到期时间。
+
+### 性能基准测试
+
+建立性能基线并跟踪随时间的变化：
+
+```bash
+# Collect 10 samples and calculate statistics
+for i in {1..10}; do
+  httptap --metrics-only https://httpbin.io/delay/1
+done | awk '/total=/ {
+  # Extract total value
+  for (i = 1; i <= NF; i++) {
+    if ($i ~ /^total=/) {
+      sub(/^total=/, "", $i)
+      sum += $i
+      values[++count] = $i
+      break
+    }
+  }
+}
+END {
+  if (count > 0) {
+    avg = sum / count
+    printf "Average: %.1f ms\n", avg
+    printf "Samples: %d\n", count
+
+    # Calculate min/max
+    min = values[1]; max = values[1]
+    for (i = 1; i <= count; i++) {
+      if (values[i] < min) min = values[i]
+      if (values[i] > max) max = values[i]
+    }
+    printf "Min: %.1f ms\n", min
+    printf "Max: %.1f ms\n", max
+    printf "Range: %.1f ms\n", (max - min)
+  }
+}'
+```
+
+输出示例：
+```
+Average: 1490.0 ms
+Samples: 10
+Min: 1445.4 ms
+Max: 1532.4 ms
+Range: 87.0 ms
+```
+
+这有助于识别性能波动并为回归测试建立可靠的基线。
+
+---
+
+## 下一步？
+
+<div class="grid cards" markdown>
+
+-   :material-console:{ .lg .middle } **[基础用法指南](../usage/basic.md)**
+
+    ---
+
+    完整的命令行参考
+
+-   :material-palette:{ .lg .middle } **[输出格式](../usage/output-formats.md)**
+
+    ---
+
+    丰富、紧凑、JSON 以及指标模式
+
+-   :material-api:{ .lg .middle } **[API 参考](../api/overview.md)**
+
+    ---
+
+    使用自定义组件扩展 httptap
+
+</div>

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,0 +1,144 @@
+---
+title: httptap
+description: 基于 Rich 的命令行工具，将一次 HTTP 请求拆解为每个有意义的阶段
+---
+
+<p align="center">
+  <img src="assets/httptap-banner.svg" alt="httptap" style="width: 100%; max-width: 1280px; height: auto;" />
+</p>
+
+# httptap
+
+<div style="text-align: center; margin-bottom: 2em;">
+  <p>
+    <a href="https://pypi.org/project/httptap/"><img src="https://img.shields.io/pypi/v/httptap?color=3775A9&label=PyPI&logo=pypi" alt="PyPI" /></a>
+    <a href="https://pypi.org/project/httptap/"><img src="https://img.shields.io/pypi/pyversions/httptap?logo=python" alt="Python Versions" /></a>
+    <a href="https://github.com/ozeranskii/httptap/actions/workflows/ci.yml"><img src="https://github.com/ozeranskii/httptap/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+    <a href="https://codecov.io/github/ozeranskii/httptap"><img src="https://codecov.io/github/ozeranskii/httptap/graph/badge.svg?token=OFOHOI1X5J" alt="Coverage" /></a>
+  </p>
+</div>
+
+`httptap` 是一个基于 Rich 的命令行工具，它将一次 HTTP 请求拆解为每个有意义的阶段——DNS 解析、TCP 连接、TLS
+握手、服务器等待、以及响应体传输，并以时间线表格、紧凑摘要或机器友好的指标形式呈现结果。它专为交互式故障排查、回归分析
+以及性能基线记录而设计。
+
+!!! tip "特别优惠"
+    <div style="text-align: center; margin-bottom: 0.6em;">
+      :gift:{ style="font-size: 1.5em; margin-right: 0.35em; vertical-align: middle;" } <span style="font-weight: 700; font-size: 1.05em;">GitKraken Pro 立省 50%</span>
+    </div>
+
+    <div style="text-align: center; font-size: 0.95em; margin-bottom: 1em; line-height: 1.5;">
+      将 GitKraken Client、用于 VS Code 的 GitLens 以及强大的 CLI 工具组合在一起，加速每一次仓库工作流。
+    </div>
+
+    <div style="display: block; text-align: center; margin-top: 1em; margin-bottom: 0.8em;">
+      [:fontawesome-solid-bolt: 领取 50% 折扣](https://gitkraken.cello.so/vY8yybnplsZ){ .md-button .md-button--primary style="font-size: 0.95em; padding: 0.6em 1.8em; font-weight: 600; letter-spacing: 0.01em; background: linear-gradient(135deg, #3949ab 0%, #5e35b1 100%); border: none; box-shadow: 0 2px 8px rgba(57, 73, 171, 0.3);" }
+    </div>
+
+    <small style="display: block; margin-top: 0.6em; opacity: 0.75; font-size: 0.85em; text-align: center;">*httptap 社区专享*</small>
+
+## 亮点
+
+- **分阶段计时** —— 基于 httpcore 的 trace 钩子进行精确测量（当底层数据不可用时提供合理的回退估算）。
+- **全部 HTTP 方法** —— GET、POST、PUT、PATCH、DELETE、HEAD、OPTIONS，均支持请求体。
+- **请求体支持** —— 内联或从文件发送 JSON、XML 或任意数据，并自动检测 Content-Type。
+- **IPv4/IPv6 感知** —— 解析器与 TLS 检查器会同时报告地址及其地址族。
+- **TLS 洞察** —— 证书 CN、SAN、颁发者、序列号、有效期窗口与到期倒计时，以及加密套件和协议版本，均直接从当前连接自动采集（无需额外握手）。
+- **多种输出模式** —— 丰富的瀑布图视图、紧凑的单行摘要，或用于脚本化的 `--metrics-only`。
+- **JSON 导出** —— 持久化完整的分步数据（包含重定向链）以便后续处理。
+- **可扩展** —— 为 DNS、TLS、计时、可视化和导出提供清晰的 Protocol 接口，便于插入自定义行为。
+
+## 快速示例
+
+**GET 请求：**
+```bash
+httptap https://httpbin.io/get
+```
+
+**带 JSON 数据的 POST 请求：**
+```bash
+httptap --data '{"name": "John"}' https://httpbin.io/post
+```
+
+![Sample Output](assets/sample-output.png)
+
+## 核心特性
+
+### 丰富的瀑布图可视化
+
+借助基于 Rich 的精美终端 UI，查看 HTTP 请求各阶段的详细计时分解。
+
+### 多种输出格式
+
+- **Rich 模式**（默认）：带颜色和格式的精美瀑布图表格
+- **紧凑模式**（`--compact`）：适合日志的单行摘要
+- **指标模式**（`--metrics-only`）：用于脚本化和自动化的原始指标
+- **JSON 导出**（`--json`）：包含重定向链的完整请求数据
+
+### 高级网络洞察
+
+- 带 IP 地址族检测（IPv4/IPv6）的 DNS 解析计时
+- TCP 连接建立计时
+- 带证书信息的 TLS 握手分析
+- 首字节时间（TTFB）测量
+- 响应体传输计时
+
+### 重定向链支持
+
+使用 `--follow` 参数跟随 HTTP 重定向，并查看链中每一步的计时分解。
+
+## 下一步？
+
+<div class="grid cards" markdown>
+
+-   :material-download:{ .lg .middle } **[安装](getting-started/installation.md)**
+
+    ---
+
+    数秒内开始使用 httptap
+
+-   :material-lightning-bolt:{ .lg .middle } **[快速开始](getting-started/quick-start.md)**
+
+    ---
+
+    通过简单示例学习基础用法
+
+-   :material-console:{ .lg .middle } **[使用指南](usage/basic.md)**
+
+    ---
+
+    探索所有特性与选项
+
+-   :material-api:{ .lg .middle } **[API 参考](api/overview.md)**
+
+    ---
+
+    用自定义组件扩展 httptap
+
+</div>
+
+## 环境要求
+
+- Python 3.10-3.15
+- macOS、Linux 或 Windows
+- 除标准网络能力外无系统依赖
+
+## 许可证
+
+Apache License 2.0 © Sergei Ozeranskii
+
+## 联系
+
+关注作者，获取来自真实经验的洞见：
+
+- :fontawesome-brands-telegram:{ .telegram } **[Telegram 频道](https://t.me/sergeiozeranskii)** —— 开发、DevOps、架构与安全。真实经验与务实洞见，绝无废话。
+- :fontawesome-brands-github: **[GitHub](https://github.com/ozeranskii)** —— 开源项目与贡献
+
+## 致谢
+
+构建于众多出色的库之上：
+
+- [httpx](https://www.python-httpx.org/) —— 现代 HTTP 客户端
+- [httpcore](https://github.com/encode/httpcore) —— 底层 HTTP 协议实现
+- [dnspython](https://www.dnspython.org/) —— Python 的 DNS 工具包
+- [Rich](https://github.com/Textualize/rich) —— 精美的终端格式化

--- a/docs/security/assurance-case.zh.md
+++ b/docs/security/assurance-case.zh.md
@@ -1,0 +1,175 @@
+---
+title: 安全保障论证
+description: httptap 的威胁模型、信任边界、所应用的安全设计原则，以及已应对的实现弱点。
+---
+
+# 安全保障论证（Security Assurance Case）
+
+本文档是 httptap 的安全保障论证。它阐述项目**为何**相信其安全属性成立，而不仅仅是这些属性**是什么**。文档结构遵循 OpenSSF Best Practices 银级（silver-level）的 `assurance_case` 准则。
+
+**最近审阅：** 2026-04-13，针对 httptap 0.5.0。
+
+保障论证是一份持续演进的文档；它会在每个大版本发布时、以及威胁态势或功能集发生实质性变化时接受审阅。修订提案以针对本文件的 pull request 形式受理。
+
+## httptap 是什么
+
+httptap 是一个命令行诊断工具。开发者提供单个 URL（并可选地附带请求头、请求体、代理、CA 包等），httptap 便执行一次 HTTP 请求（或一段简短的重定向链），并渲染每个阶段的计时与 TLS 信息。它**不会**：
+
+- 接受来自不受信任对端的网络输入（它不是服务器）；
+- 管理用户账户、会话或长期凭证；
+- 执行远程代码或求值服务器提供的脚本；
+- 在可选的 `--json` 导出之外持久化任何机密或用户数据。
+
+## 安全需求
+
+项目承诺以下可观测的安全属性。每一项都在下文各节中映射到相应的支撑论据。
+
+| # | 需求 | 理由 |
+|---|-------------|-----------|
+| SR-1 | 对每个 HTTPS 目标默认启用 TLS 证书校验。 | 默认阻止被动和主动的中间人攻击（MITM）。 |
+| SR-2 | 明文 HTTP、削弱的 TLS 或自定义 CA 包均需用户显式选择启用。 | 确保不安全的配置始终是有意为之。 |
+| SR-3 | 用户提供的凭证（例如 `Authorization` 请求头）仅转发到原始 URL，不会泄露给位于不同主机上的重定向目标。 | 防止通过开放重定向窃取凭证。 |
+| SR-4 | 工具不会执行远程主机所提供的内容。 | 服务器无从获得任何代码执行原语。 |
+| SR-5 | 发布制品（PyPI wheel/sdist、容器镜像、git 标签和发布提交）均经过签名，且其构建来源可验证。 | 保护用户免受被篡改的分发包侵害。 |
+| SR-6 | 所有 CI 工作流令牌均遵循最小权限并按 SHA 固定。 | 缩减构建流水线的攻击面。 |
+| SR-7 | 对供应链（依赖、GitHub Actions、Docker 镜像）进行已知漏洞监控。 | 及时修补上游弱点。 |
+
+## 信任边界
+
+```
+   ┌─────────────────────┐
+   │ CLI user            │   trusted
+   │ (argv, stdin, env)  │
+   └──────────┬──────────┘
+              │
+              ▼
+   ┌─────────────────────┐
+   │ httptap process     │   trusted
+   │ (Python 3.10+)      │
+   └──────────┬──────────┘
+              │  TLS/HTTP  ◄─── untrusted: network, proxy, remote host
+              ▼
+   ┌─────────────────────┐
+   │ Remote HTTP server  │   untrusted
+   └─────────────────────┘
+```
+
+- **用户 → httptap** 是受信任的：假定用户有正当理由发起任何给定请求。输入校验仍会拒绝格式错误的 URL、方法、超时等，以防止操作者的失误。
+- **httptap → 网络 → 远程服务器** 是不受信任的。所有跨越此边界的数据都被视为受攻击者控制：响应头、状态码、`Location` 值、TLS 证书、内容体。
+- **构建流水线 → PyPI / GitHub Releases** 是一个独立的信任边界，由 GitHub OIDC（无长期密钥）、Sigstore 签名以及按 SHA 固定的 actions 加以保护。
+
+## 威胁模型
+
+以下威胁按适用于诊断型 HTTP 客户端的 STRIDE 类别列出。超出客户端范围的威胁（例如服务器端 DoS）作为非目标被明确排除。
+
+| STRIDE | 威胁 | 缓解措施 |
+|--------|--------|------------|
+| **Spoofing（伪装）** | 攻击者冒充目标 HTTPS 服务器。 | 默认启用 TLS 证书校验（SR-1）；`--ignore-ssl` 需显式选择启用，并被记载为不安全（SR-2）。 |
+| **Spoofing（伪装）** | 恶意的 PyPI 镜像提供被篡改的 wheel。 | PyPI 使用 TLS；发布制品经 Sigstore 签名并带有 SLSA v1.0 来源证明（SR-5）；用户可使用 `gh attestation verify` 进行验证。 |
+| **Tampering（篡改）** | GitHub Releases 上被修改的制品。 | 同上——构建来源证明允许独立验证。 |
+| **Tampering（篡改）** | CI 流水线因第三方 action 被攻陷而遭投毒。 | 每个 action 都按 SHA 固定（由 Scorecard Pinned-Dependencies 10/10 和 zizmor pedantic 强制执行）；Dependabot 提交 PR 以更新固定项（SR-6、SR-7）。 |
+| **Repudiation（抵赖）** | — | 超出范围；httptap 不是多用户系统。 |
+| **Information disclosure（信息泄露）** | `-H Authorization` 中的凭证泄露给位于不同主机上的重定向目标。 | 按 httpx 默认行为，重定向链保留按主机限定的请求头；跨源重定向会丢弃敏感请求头（SR-3）。 |
+| **Information disclosure（信息泄露）** | `--json` 导出将认证请求头写入磁盘。 | SECURITY.md 和 docs/troubleshooting.md 建议用户在共享导出前对认证请求头进行脱敏。 |
+| **Information disclosure（信息泄露）** | 在不安全的代理上发生 MITM。 | 代理 URL 的协议方案会被校验；对敏感目标推荐使用 `socks5h://` / `https://`；代理来源会在输出和 JSON 中报告以供审计。 |
+| **Denial of service（拒绝服务）** | 恶意服务器流式发送无界的请求体。 | 通过 `--timeout` 设定每请求超时（默认 20 秒）；传输阶段受同一截止时限约束。 |
+| **Denial of service（拒绝服务）** | 恶意服务器流式发送 zip 炸弹或巨大的请求体。 | httptap 除为计时指标统计字节数外，不会解码或持久化请求体，因此内存开销是线性的，并受超时约束。 |
+| **Elevation of privilege（权限提升）** | 恶意响应体触发解析器 RCE。 | 请求体从不按内容解析——只读取其长度。不进行任何 HTML、JS 或内嵌脚本的解释（SR-4）。 |
+| **Elevation of privilege（权限提升）** | 恶意 CLI 参数在下游调用中触发 shell 注入。 | 参数由 `argparse` 解析（无 shell），并作为 `list[str]` 转发给 `httpx`（无 shell）；请求路径中不存在任何 shell 调用。 |
+
+### 超出范围的威胁
+
+- **在开发者机器上拥有本地代码执行能力的攻击者。** 超出范围——该攻击者已然掌控了进程本身。
+- **控制用户终端 / TTY 的攻击者。** 超出范围。
+- **针对 TLS 本身的密码分析攻击。** 委托给 OpenSSL；缓解措施继承自系统 Python 构建。
+- **后量子威胁。** 由上游跟踪（OpenSSL / Python）；对 httptap 自身而言超出范围。
+
+## 所应用的安全设计原则
+
+映射到 Saltzer & Schroeder（1975）及现代补充原则。
+
+| 原则 | 在 httptap 中的应用 |
+|-----------|-----------------------|
+| 机制经济性（Economy of mechanism） | 代码库小（约 2 kLoC）、用途单一、无插件加载器、无运行时配置文件。 |
+| 失败安全默认（Fail-safe defaults） | 默认启用 TLS 校验、合理的默认超时、优先使用 HTTP/2、默认不跟随重定向。 |
+| 完全仲裁（Complete mediation） | 每个出站请求都经由 `HTTPClientRequestExecutor` 路由；不存在次要或遗留代码路径。 |
+| 开放设计（Open design） | 整个代码库以 Apache-2.0 许可托管于 GitHub；不依赖隐晦性来保障安全。 |
+| 权限分离（Separation of privilege） | 发布流水线与开发环境相分离；PyPI 发布使用由 OIDC 把关的 GitHub Environment。 |
+| 最小权限（Least privilege） | 每个 CI 作业都声明显式的最小 `permissions:`；没有任何工作流使用 `write-all`。Token-Permissions 的 Scorecard 检查评分为 10/10。 |
+| 最少公共机制（Least common mechanism） | 各次运行之间无共享状态（单请求工具）；无缓存或后台守护进程。 |
+| 心理可接受性（Psychological acceptability） | 兼容 curl 的参数别名（`-X`、`-L`、`-k`、`-x`、`-H`）保持心智模型的熟悉感。 |
+| 工作因子（Work factor） | 相较于开发者本地的 `curl` 调用，攻击者所能获得的收益基本为零——httptap 暴露的内容不比 curl 更多。 |
+| 入侵记录（Compromise recording） | JSON 导出记录了完整的请求/响应元数据以及代理来源，因此事后取证十分直接。 |
+| 纵深防御（Defense in depth） | 输入校验 + TLS 校验 + 固定的构建依赖 + SAST + 机密扫描 + Dependabot + 已签名的发布制品。 |
+
+## 所应对的常见实现弱点
+
+源自 [CWE Top 25 (2023)](https://cwe.mitre.org/top25/) 和 [OWASP ASVS 4.0](https://owasp.org/www-project-application-security-verification-standard/)。未列出的条目要么不适用于 HTTP 客户端，要么由上游处理。
+
+| CWE | 弱点 | 应对措施 |
+|-----|----------|----------------|
+| CWE-20 | 不当的输入校验 | `argparse` 的枚举/类型强制转换；对 URL/方法/超时/代理进行显式检查。 |
+| CWE-22 | 路径遍历（在 `@file` 数据加载器中） | 路径原样取自用户；从不使用服务器提供的路径来打开文件。 |
+| CWE-78 | 操作系统命令注入 | 请求路径中不对用户可控数据调用 `subprocess`/`os.system`。 |
+| CWE-79 | XSS | 不进行 HTML 渲染；输出为纯文本或经转义的 Rich 渲染标记。 |
+| CWE-89 | SQL 注入 | 无数据库。 |
+| CWE-94 | 代码注入 | 不使用 `eval`/`exec`；从不解析响应体。 |
+| CWE-116 | 不当的输出编码 | Rich 安全地处理终端转义序列；JSON 导出使用带严格转义的 `json.dumps`。 |
+| CWE-200 | 敏感信息泄露 | 认证请求头不会被复制到日志输出；SECURITY.md 与文档提醒用户在共享前对 JSON 导出脱敏。 |
+| CWE-295 | 不当的证书校验 | 默认启用 TLS 校验；`--ignore-ssl` 仅在显式选择时启用，并有明确记载。 |
+| CWE-319 | 明文传输 | 优先使用 HTTPS；纯 HTTP 需显式的 `http://` URL；代理来源会被报告。 |
+| CWE-327 | 弱加密 | 委托给标准库 `ssl`；弱算法仅在诊断远程服务器时才浮现。 |
+| CWE-330 | 随机性不足 | 除 OpenSSL 为 TLS 提供的 CSPRNG 外不使用任何 RNG。 |
+| CWE-352 | CSRF | 不适用——httptap 是客户端，不是服务器。 |
+| CWE-400 | 不受控的资源消耗 | 每请求超时；有界的重定向链（最多 10 次）。 |
+| CWE-502 | 不安全的反序列化 | 仅使用 `json.loads`；不使用 pickle、yaml.load 或 marshal。 |
+| CWE-601 | 开放重定向（凭证泄露） | 按主机限定的请求头处理继承自 httpx 的行为——跨源重定向会丢弃敏感的认证请求头。 |
+| CWE-918 | SSRF | httptap 是客户端；它不代表其他系统代理请求。 |
+
+## 供应链保障
+
+支撑发布完整性属性（SR-5）：
+
+- **发布**：通过 GitHub OIDC Trusted Publishing 发布到 PyPI（并以 TestPyPI 作为预生产冒烟测试）——任何地方都没有长期的 PyPI 令牌。PEP 740 证明在 PyPI 上以“Verified publisher”呈现。
+- **容器镜像**：多架构（linux/amd64、linux/arm64）镜像使用 Buildx 构建并推送到 GHCR，使用 cosign 无密钥签名，并附带附加到镜像仓库的 SLSA 构建来源证明。
+- **Git 签名**：发布提交和带注解的标签使用 [gitsign](https://github.com/sigstore/gitsign)（经 Fulcio 的 x.509 + Rekor 透明日志）以无密钥方式签名，采用发布工作流的 OIDC 身份。
+- **签名**：通过 `actions/attest-build-provenance` 和 cosign 进行 Sigstore 无密钥签名。签名密钥是短期的，由 Fulcio 按每次运行签发，并可通过 Rekor 透明日志验证。
+- **来源证明**：SLSA v1.0 证明伴随每个 wheel、sdist 和容器镜像摘要。
+- **Dockerfile 检查**：`hadolint` 在每个 PR 上运行，失败阈值为警告级别。
+- **固定（Pinning）**：每个工作流中的每个 GitHub Action 都按 SHA 固定；由 Scorecard Pinned-Dependencies 和 zizmor pedantic 在每个 PR 上强制执行。
+- **依赖跟踪**：在发布期间生成 CycloneDX 和 SPDX 格式的 SBOM，并作为 GitHub Release 资产附上。
+- **可利用性披露**：一份 OpenVEX 文档（`httptap-X.Y.Z.openvex.json`）随 SBOM 一同发布，为每个依赖的 CVE 声明 `httptap` 是否实际受影响。真实来源以版本化形式保存在 [`.vex/httptap.openvex.json`](https://github.com/ozeranskii/httptap/blob/main/.vex/httptap.openvex.json)；消费 VEX 的扫描器（Grype、Trivy、Snyk）借助它抑制针对不可达的脆弱代码路径的误报告警。
+
+用户可以独立验证已下载的制品：
+
+```shell
+gh attestation verify dist/httptap-X.Y.Z-py3-none-any.whl \
+  --repo ozeranskii/httptap
+```
+
+## 已知残余风险
+
+以下风险是被记载而非缓解的。它们代表的是显式的权衡取舍，而非疏漏。
+
+- **单一维护者。** Bus factor 为 1（在 GOVERNANCE.md 中跟踪）。连续性计划缓解了运营层面的单点故障，但未缓解代码审查层面的单点故障：单个审查者可以在没有第二双眼睛的情况下合并变更。Pre-commit、CI 门禁和公开的审计轨迹部分弥补了这一点。
+- **无运行时沙箱。** httptap 以用户的全部权限运行。这对于开发者诊断工具而言是恰当的，但意味着 `httptap` 自身的缺陷会以用户的权限运行。
+- **TLS 信任锚继承自操作系统。** 如果操作系统信任库被攻陷（例如企业 MITM 代理安装了私有 CA），httptap 无法察觉。JSON 导出中的 `network.tls_custom_ca` 和 `proxy_source` 字段会记录是否使用了自定义 CA 包或代理。
+
+## 变更历史
+
+| 日期 | 备注 |
+|------|-------|
+| 2026-04-12 | httptap 0.4.7 的首个保障论证（银级提交）。 |
+| 2026-04-13 | 面向 0.5.0 的开源加固：gitsign 签名的发布提交/标签、TestPyPI 预检、带 SLSA 来源证明的已签名 GHCR 容器镜像、CI 中的 hadolint、man-page 制品。 |
+
+---
+
+## 参考资料
+
+- [SECURITY.md](https://github.com/ozeranskii/httptap/blob/main/SECURITY.md) —— 漏洞报告流程与受支持的版本。
+- [GOVERNANCE.md](https://github.com/ozeranskii/httptap/blob/main/GOVERNANCE.md) —— 项目角色、决策与连续性计划。
+- [ROADMAP.md](https://github.com/ozeranskii/httptap/blob/main/ROADMAP.md) —— 范围、非目标与弃用策略。
+- [故障排查与常见问题](../troubleshooting.md) —— 运维指引。
+- [CWE Top 25](https://cwe.mitre.org/top25/) 和
+  [OWASP ASVS 4.0](https://owasp.org/www-project-application-security-verification-standard/)
+  —— 实现弱点的参考目录。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,7 +53,7 @@ The explicit `-x/--proxy` flag always wins over environment variables. Check:
 2. The scheme matches the target — `HTTPS_PROXY` is used for `https://` URLs,
    `HTTP_PROXY` for `http://`.
 3. The target host isn't matched by `NO_PROXY`. Check the `proxy_source` field
-   in the JSON export; if it says `env:no_proxy`, your host is excluded.
+   in the JSON export; if it says `NO_PROXY`, your host is excluded.
 
 ### `NO_PROXY` pattern reference
 

--- a/docs/troubleshooting.zh.md
+++ b/docs/troubleshooting.zh.md
@@ -1,0 +1,188 @@
+---
+title: 故障排查与常见问题
+description: 运行 httptap 时的常见问题、错误信息与诊断。
+---
+
+# 故障排查与常见问题
+
+本页汇集了用户在运行 `httptap` 时最常遇到的问题和错误。如果你的问题未在此列出，请
+[提交 issue](https://github.com/ozeranskii/httptap/issues)，并附上确切的
+命令、JSON 导出（如有）以及相关的终端输出。
+
+## TLS 与证书
+
+### `TLS handshake failed: CERTIFICATE_VERIFY_FAILED`
+
+服务器出示了一个你的信任库无法识别的证书。
+
+- **非生产主机上的自签名或过期证书** —— 添加 `--ignore-ssl`
+  （禁用校验，仅在可信网络中使用）。
+- **内部 CA** —— 将 `--cacert`（别名 `--ca-bundle`）指向你的 PEM 包。
+- **系统信任库已过时** —— 在 Linux 上更新 `ca-certificates`，或
+  刷新你 Python 环境中的 `certifi`（`uv pip install --upgrade certifi`）。
+
+JSON 导出会显示 `network.tls_verified: false`，且在使用 `--cacert` 时会显示
+`network.tls_custom_ca: true`。
+
+### 证书显示 `cert_days_left: null` 或负值
+
+`cert_days_left` 从叶证书的 `notAfter` 字段解析而来。`null`
+值表示无法获取/解析该证书——通常是 TLS
+在收到证书前就已中止，或使用了 `--ignore-ssl`（禁用校验后，对端证书不会
+以已解析字典的形式呈现，因此 `cert_cn`/`cert_days_left` 以及其他 `cert_*` 字段会保持
+`null`，而 `tls_version`/`tls_cipher` 仍会报告）。**负**
+值表示证书已过期。
+
+### `--ignore-ssl` 仍以 `DH_KEY_TOO_SMALL` / `WRONG_VERSION_NUMBER` 失败
+
+现代 OpenSSL 构建出于安全考虑移除了某些加密算法和 DH 参数。
+`--ignore-ssl` 会放宽校验和协议约束，但无法找回
+已从二进制文件中移除的加密套件（RC4、3DES、弱 DH）。
+变通方案：使用较老的 curl、终止 TLS 的代理，或重新编译 OpenSSL。
+
+## 代理
+
+### `--proxy` 被忽略
+
+显式的 `-x/--proxy` 参数始终优先于环境变量。请检查：
+
+1. 你没有误传空字符串——`--proxy ""` 会**显式
+   禁用**基于环境变量的代理并强制直连。
+2. 协议方案与目标匹配——`HTTPS_PROXY` 用于 `https://` URL，
+   `HTTP_PROXY` 用于 `http://`。
+3. 目标主机未被 `NO_PROXY` 匹配。检查 JSON 导出中的 `proxy_source`
+   字段；如果它显示 `NO_PROXY`，说明你的主机被排除了。
+
+### `NO_PROXY` 模式参考
+
+- 精确主机：`api.internal.example`
+- 域名后缀：`.internal.example`（匹配 `foo.internal.example`）
+- 通配符：`*`（排除一切）
+- 多个条目：逗号分隔，去除首尾空白
+
+**不**支持 IP/CIDR 匹配——这遵循广泛采用的 curl
+行为。
+
+## HTTP/2
+
+### 即使未传 `--no-http2`，服务器仍以 HTTP/1.1 响应
+
+HTTP/2 需要在 TLS 握手期间进行 ALPN 协商。如果：
+
+- 服务器未在 ALPN 中通告 `h2`，**或**
+- 目标使用纯 `http://`（不支持 h2c），
+
+httptap 会回退到 HTTP/1.1。请检查 JSON 导出中的
+`network.http_version`。
+
+### 如何强制使用 HTTP/1.1？
+
+使用 `--no-http2`（兼容 curl 的别名 `--http1.1`）。这会完全禁用 ALPN h2
+协商。
+
+## 计时
+
+### `timing.is_estimated: true` —— 这是什么意思？
+
+httptap 通常从 `httpcore` 的 trace 钩子获取各阶段计时。当这些
+钩子不可用时（例如绕过它们的自定义 `RequestExecutor`，
+或某些 HTTP/2 连接复用路径），httptap 会回退到用启发式方法拆分
+总耗时。这样的分解在方向上仍然
+正确，但不如默认路径精确。
+
+### 为什么连续两次运行显示的 `dns_ms` 差异巨大？
+
+系统解析器会缓存条目。第一次请求要支付到你 DNS 服务器的完整 RTT；
+后续请求则命中缓存（往往是亚毫秒级）。
+若要绕过缓存，请通过 Python API 提供自定义解析器，或刷新
+本地缓存（例如 macOS 上的 `sudo dscacheutil -flushcache`，systemd 上的
+`resolvectl flush-caches`）。
+
+### `ttfb_ms` 为零或低于 `connect_ms`
+
+在连接复用时（后续重定向步骤的 keep-alive、HTTP/2 流
+多路复用），该步骤没有新的 TCP 连接——`connect_ms` 将为
+`0` 或非常小。`ttfb_ms` 测量的是该特定请求上直到收到首个响应字节的
+时间；跨步骤将其与 `connect_ms` 比较，看起来古怪是意料之中的。
+
+## 输出
+
+### 我的终端没有颜色
+
+httptap 遵循 [`NO_COLOR`](https://no-color.org) 约定和 Rich 的
+TTY 检测：
+
+- 若设置了 `NO_COLOR`，请取消设置。
+- 将 stdout 管道到文件或另一个进程会禁用颜色；设置
+  `FORCE_COLOR=1` 可覆盖。
+- `TERM=dumb` 同样会禁用渲染。
+
+### `--metrics-only` 不再显示 `proxy=` 字段
+
+它并没有——该字段始终存在。旧的截图/示例可能早于
+该变更。预期格式：
+
+```
+Step 1: dns=30.1 ... tls_version=TLSv1.2 proxy=direct
+```
+
+`proxy` 的取值来源：`direct`、`none`（命中 NO_PROXY）、`disabled`（`--proxy ""`）、
+带 `proxy_from=...` 提示的 `<url>`。
+
+## 脚本化与 CI
+
+### 我应该检查哪些退出码？
+
+参见 README 中的 [Exit Codes](https://github.com/ozeranskii/httptap#exit-codes)
+部分。典型的 CI 模式：将 `75`（网络 / TLS，瞬时）视为
+可重试，遇到 `64`（用法）、`70`（缺陷）和 `4`（若你提供了
+`--slo` 的 SLO 违规）则直接失败。
+
+### 即使请求很慢，我的 `--slo` 预算却从不触发。
+
+请检查三件事：
+
+1. 你设置的键映射到一个真实存在的计时阶段。有效的键是
+   `dns`、`connect`、`tls`、`ttfb`、`wait`、`xfer`、`total`——其他任何
+   值都会以退出码 `64`（SLO Error 面板）拒绝该命令。
+2. SLO 是在**最终成功的步骤**上评估的，而非中间的
+   重定向。如果 `--follow` 经过了若干跳，而最后一
+   步很快，那么整个链的总时间不会被比较。请用 `total`
+   对照终端请求的预算，或在需要逐步保证时从
+   `--json` 手动聚合。
+3. 如果每一步都出错，SLO 会被完全跳过——退出码
+   反映的是网络故障（通常是 `75`）。此时 `--metrics-only` 输出中
+   不会出现 `slo=` 标记。
+
+### httptap 能输出 Prometheus 指标吗？
+
+开箱即用尚不支持。请使用 `--metrics-only` 并用 `awk`/`jq` 做后处理，或
+解析 `--json` 导出。专用的 exporter 已在路线图中——关注
+[issue 跟踪器](https://github.com/ozeranskii/httptap/issues) 获取更新。
+
+## Python API
+
+### `ImportError: cannot import name 'HTTPMethod' from 'httptap'`
+
+`HTTPMethod` 位于 `httptap.constants`，而非顶层命名空间：
+
+```python
+from httptap import HTTPTapAnalyzer
+from httptap.constants import HTTPMethod
+```
+
+### 我的自定义解析器没有被调用
+
+`HTTPTapAnalyzer` 仅将注入的解析器用于诊断性的 DNS 查询
+计时。实际的连接解析仍由 `httpx`/`httpcore` 执行。
+若要让真实连接经过你的解析器，还需实现自定义的
+`RequestExecutor`。
+
+---
+
+## 仍未解决？
+
+- 使用 `--metrics-only` 运行，并在你的报告中包含完整输出。
+- 使用 `--json report.json` 运行并附上该报告（请脱敏认证请求头）。
+- 确认版本——`httptap --version`——我们仅支持最新的
+  次要版本。

--- a/docs/usage/advanced.zh.md
+++ b/docs/usage/advanced.zh.md
@@ -1,14 +1,14 @@
 ---
-description: Proxies, custom CA bundles, the Python API, and extension patterns for advanced httptap usage.
+description: 代理、自定义 CA 包、Python API 以及用于 httptap 高级用法的扩展模式。
 ---
 
-# Advanced Features
+# 高级功能
 
-This guide covers advanced usage patterns and customization options for httptap.
+本指南介绍 httptap 的高级用法模式和自定义选项。
 
-## Custom DNS Resolution
+## 自定义 DNS 解析
 
-You can provide custom DNS resolver implementations by using the Python API. httptap always dials the resolved IP address (IPv4/IPv6) while preserving the original hostname for the `Host` header and TLS SNI. IPv6 literals are bracketed automatically, so custom resolvers only need to return the correct IP/family tuple.
+你可以通过 Python API 提供自定义的 DNS 解析器实现。httptap 始终拨号连接到解析出的 IP 地址（IPv4/IPv6），同时为 `Host` 请求头和 TLS SNI 保留原始主机名。IPv6 字面量会被自动加上方括号，因此自定义解析器只需返回正确的 IP/地址族元组即可。
 
 ```python
 from httptap import HTTPTapAnalyzer, SystemDNSResolver
@@ -29,9 +29,9 @@ analyzer = HTTPTapAnalyzer(dns_resolver=CustomDNSResolver())
 steps = analyzer.analyze_url("https://httpbin.io")
 ```
 
-## Custom TLS Inspection
+## 自定义 TLS 检查
 
-Implement custom TLS inspection logic to extract additional certificate information.
+实现自定义的 TLS 检查逻辑，以提取额外的证书信息。
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -51,11 +51,11 @@ class CustomTLSInspector:
 analyzer = HTTPTapAnalyzer(tls_inspector=CustomTLSInspector())
 ```
 
-## Programmatic Usage
+## 编程化使用
 
-Use httptap as a Python library for integration into your applications.
+将 httptap 作为 Python 库使用，以集成到你自己的应用程序中。
 
-### Basic Analysis
+### 基础分析
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -69,7 +69,7 @@ for step in steps:
     print(f"Total time: {step.timing.total_ms:.2f}ms")
 ```
 
-### With Custom Headers
+### 使用自定义请求头
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -80,7 +80,7 @@ headers = {"Authorization": "Bearer token123", "Accept": "application/json"}
 steps = analyzer.analyze_url("https://httpbin.io/bearer", headers=headers)
 ```
 
-### Following Redirects
+### 跟随重定向
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -91,7 +91,7 @@ steps = analyzer.analyze_url("https://httpbin.io/redirect/3")
 print(f"Total steps in redirect chain: {len(steps)}")
 ```
 
-### Sending Request Body
+### 发送请求体
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -106,24 +106,20 @@ steps = analyzer.analyze_url(
 )
 ```
 
-## Ignoring TLS Verification
+## 忽略 TLS 校验
 
-When troubleshooting staging environments or hosts with self-signed certificates, you can skip TLS validation:
+在排查预发布环境或使用自签名证书的主机时，你可以跳过 TLS 校验：
 
 ```shell
 httptap --ignore-ssl https://self-signed.badssl.com
 ```
 
-The request still records TLS metadata, but certificate errors are suppressed so you can focus on the protocol flow. Only use this flag in trusted environments because it disables protection against man-in-the-middle attacks.
-The client relaxes many cipher and protocol requirements (weak hashes,
-older TLS versions, small DH groups) so that legacy endpoints are more
-likely to complete the handshake. Extremely deprecated algorithms that
-OpenSSL removes entirely (e.g., RC4, 3DES on some platforms) may still
-fail even in this mode.
+请求仍会记录 TLS 元数据，但证书错误会被抑制，以便你专注于协议流程。请仅在可信环境中使用此参数，因为它会禁用针对中间人攻击的保护。
+客户端会放宽许多加密套件和协议要求（弱哈希、较老的 TLS 版本、较小的 DH 群），使旧式端点更有可能完成握手。某些被 OpenSSL 完全移除的极度弃用算法（例如某些平台上的 RC4、3DES）即使在此模式下仍可能失败。
 
-## Using Proxies { #using-proxies }
+## 使用代理 { #using-proxies }
 
-Direct requests through an outbound proxy (HTTP, HTTPS, SOCKS5/SOCKS5H):
+通过出站代理（HTTP、HTTPS、SOCKS5/SOCKS5H）转发请求：
 
 ```shell
 httptap --proxy https://proxy.internal:8443 https://httpbin.io/get
@@ -133,62 +129,58 @@ httptap --proxy https://proxy.internal:8443 https://httpbin.io/get
 httptap --proxy socks5h://proxy.internal:1080 https://httpbin.io/get
 ```
 
-Ignore all proxy environment variables and connect directly:
+忽略所有代理环境变量并直接连接：
 
 ```shell
 httptap --proxy "" https://httpbin.io/get
 ```
 
-The Rich output and JSON export include the proxy URI and its source
-(e.g., `(from arg --proxy)`, `(from env HTTPS_PROXY)`,
-`(bypassed by env no_proxy)`) so you can confirm which path was used.
+Rich 输出和 JSON 导出会包含代理 URI 及其来源（例如 `(from arg --proxy)`、`(from env HTTPS_PROXY)`、`(bypassed by env no_proxy)`），以便你确认实际使用的路径。
 
-### Proxy Protocols and DNS Resolution
+### 代理协议与 DNS 解析
 
-httptap supports four proxy protocols, each with different DNS resolution behavior:
+httptap 支持四种代理协议，每种协议的 DNS 解析行为各不相同：
 
 | Protocol   | DNS Resolved By | Use Case |
 |------------|----------------|----------|
-| `socks5h://` | Proxy server | Privacy, corporate networks, access to internal DNS |
-| `http://`    | Proxy server | Standard HTTP proxies (CONNECT method) |
-| `https://`   | Proxy server | Encrypted connection to proxy |
-| `socks5://`  | Client (local) | When you need to control DNS resolution |
+| `socks5h://` | 代理服务器 | 隐私保护、企业网络、访问内部 DNS |
+| `http://`    | 代理服务器 | 标准 HTTP 代理（CONNECT 方法） |
+| `https://`   | 代理服务器 | 与代理之间的加密连接 |
+| `socks5://`  | 客户端（本地） | 当你需要控制 DNS 解析时 |
 
-The `h` suffix in `socks5h` stands for "hostname" (a curl convention). With `socks5h://`, the hostname is sent to the proxy which resolves it. With `socks5://`, the client resolves DNS locally and sends the IP to the proxy.
+`socks5h` 中的 `h` 后缀代表 "hostname"（一种 curl 约定）。使用 `socks5h://` 时，主机名会被发送到代理，由代理进行解析。使用 `socks5://` 时，客户端在本地解析 DNS，并将 IP 发送给代理。
 
-### Environment Variable Proxies
+### 环境变量代理
 
-When no `--proxy` flag is provided, httptap checks environment variables:
+当未提供 `--proxy` 参数时，httptap 会检查环境变量：
 
-1. `no_proxy` / `NO_PROXY` - Comma-separated list of hosts to bypass (lowercase takes priority)
-2. `https_proxy` / `HTTPS_PROXY` - Proxy for HTTPS requests (lowercase takes priority)
-3. `http_proxy` / `HTTP_PROXY` - Proxy for HTTP requests (lowercase takes priority)
-4. `all_proxy` / `ALL_PROXY` - Fallback proxy for all protocols
+1. `no_proxy` / `NO_PROXY` - 逗号分隔的需要绕过代理的主机列表（小写优先）
+2. `https_proxy` / `HTTPS_PROXY` - 用于 HTTPS 请求的代理（小写优先）
+3. `http_proxy` / `HTTP_PROXY` - 用于 HTTP 请求的代理（小写优先）
+4. `all_proxy` / `ALL_PROXY` - 用于所有协议的回退代理
 
-The `--proxy` flag always takes precedence over environment variables.
+`--proxy` 参数始终优先于环境变量。
 
-**NO_PROXY patterns:**
+**NO_PROXY 模式：**
 
-- `*` - Bypass proxy for all hosts
-- `example.com` - Exact hostname match
-- `.example.com` - All subdomains of example.com
-- `sub.example.com` - Exact subdomain match
+- `*` - 对所有主机绕过代理
+- `example.com` - 精确主机名匹配
+- `.example.com` - example.com 的所有子域名
+- `sub.example.com` - 精确子域名匹配
 
-## Custom CA Bundles
+## 自定义 CA 包
 
-For internal endpoints signed by a private CA, supply a PEM bundle with `--cacert`:
+对于由私有 CA 签名的内部端点，使用 `--cacert` 提供一个 PEM 包：
 
 ```bash
 httptap --cacert ~/certs/company-ca.pem https://internal-api.example.com/health
 ```
 
-CLI output will show `TLS CA: custom bundle` to indicate the non-system trust store was used. JSON exports include `network.tls_custom_ca: true` so downstream tools can detect custom trust. The flag is mutually exclusive with `--ignore-ssl`.
+CLI 输出会显示 `TLS CA: custom bundle`，以表明使用了非系统信任库。JSON 导出会包含 `network.tls_custom_ca: true`，以便下游工具检测自定义信任配置。该参数与 `--ignore-ssl` 互斥。
 
-## Custom Request Executors
+## 自定义请求执行器
 
-For fully customized behavior you can provide your own request executor.
-Executors receive all parameters packaged inside `RequestOptions`, so new
-flags added by httptap remain backward compatible.
+对于完全自定义的行为，你可以提供你自己的请求执行器。执行器会接收打包在 `RequestOptions` 中的所有参数，因此 httptap 新增的参数仍保持向后兼容。
 
 ```python
 from httptap import HTTPTapAnalyzer, RequestExecutor, RequestOptions, RequestOutcome
@@ -223,9 +215,9 @@ analyzer.analyze_url("https://httpbin.io/get", headers={"X-Debug": "1"})
 print(executor.last_options.headers)  # {'X-Debug': '1'}
 ```
 
-## Custom Visualization
+## 自定义可视化
 
-Create your own visualization by implementing the `Visualizer` protocol.
+通过实现 `Visualizer` 协议来创建你自己的可视化。
 
 ```python
 from httptap.models import StepMetrics
@@ -249,9 +241,9 @@ for step in steps:
     visualizer.render(step)
 ```
 
-## Custom Export Formats
+## 自定义导出格式
 
-Implement custom export formats beyond JSON.
+实现 JSON 之外的自定义导出格式。
 
 ```python
 from collections.abc import Sequence
@@ -291,9 +283,9 @@ exporter = CSVExporter()
 exporter.export(steps, "https://httpbin.io", "output.csv")
 ```
 
-## Performance Monitoring
+## 性能监控
 
-Use httptap for continuous performance monitoring.
+使用 httptap 进行持续的性能监控。
 
 ```python
 import time
@@ -323,9 +315,9 @@ def monitor_endpoint(url: str, interval: int = 60):
 monitor_endpoint("https://httpbin.io/status/200", interval=60)
 ```
 
-## Batch Analysis
+## 批量分析
 
-Analyze multiple URLs concurrently.
+并发分析多个 URL。
 
 ```python
 from concurrent.futures import ThreadPoolExecutor
@@ -351,9 +343,9 @@ for url, total_ms in results:
     print(f"{url}: {total_ms:.2f}ms")
 ```
 
-## Error Handling
+## 错误处理
 
-Handle errors gracefully when analyzing URLs.
+在分析 URL 时优雅地处理错误。
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -368,9 +360,9 @@ else:
     print(f"Status: {step.response.status}")
 ```
 
-## Integration with Testing Frameworks
+## 与测试框架集成
 
-Use httptap in your test suites to verify performance requirements.
+在你的测试套件中使用 httptap 来验证性能要求。
 
 ```python
 import pytest
@@ -403,9 +395,9 @@ def test_tls_configuration():
     assert steps[0].network.cert_days_left > 30, f"Certificate expiring soon: {steps[0].network.cert_days_left} days"
 ```
 
-## Environment-Specific Configuration
+## 特定环境配置
 
-Configure httptap differently for various environments.
+为不同环境分别配置 httptap。
 
 ```python
 import os
@@ -437,9 +429,9 @@ analyzer = HTTPTapAnalyzer(
 steps = analyzer.analyze_url("https://httpbin.io/status/200")
 ```
 
-## Debugging Tips
+## 调试技巧
 
-### Enable Detailed Logging
+### 启用详细日志
 
 ```python
 import logging
@@ -453,7 +445,7 @@ analyzer = HTTPTapAnalyzer()
 steps = analyzer.analyze_url("https://httpbin.io")
 ```
 
-### Inspect Raw HTTP Traffic
+### 检查原始 HTTP 流量
 
 ```python
 from httptap import HTTPTapAnalyzer
@@ -470,26 +462,26 @@ for key, value in step.response.headers.items():
 
 ---
 
-## What's Next?
+## 下一步？
 
 <div class="grid cards" markdown>
 
--   :material-api:{ .lg .middle } **[API Reference](../api/overview.md)**
+-   :material-api:{ .lg .middle } **[API 参考](../api/overview.md)**
 
     ---
 
-    Detailed interface documentation
+    详细的接口文档
 
--   :material-account-group:{ .lg .middle } **[Contributing Guide](../development/contributing.md)**
-
-    ---
-
-    Extend httptap and contribute
-
--   :material-rocket-launch:{ .lg .middle } **[Release Process](../development/release.md)**
+-   :material-account-group:{ .lg .middle } **[贡献指南](../development/contributing.md)**
 
     ---
 
-    How releases work
+    扩展 httptap 并参与贡献
+
+-   :material-rocket-launch:{ .lg .middle } **[发布流程](../development/release.md)**
+
+    ---
+
+    发布是如何进行的
 
 </div>

--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -1,3 +1,7 @@
+---
+description: Run httptap from the command line and read the per-phase timing breakdown of any HTTP request.
+---
+
 # Basic Usage
 
 ## Command-Line Interface

--- a/docs/usage/basic.zh.md
+++ b/docs/usage/basic.zh.md
@@ -1,0 +1,375 @@
+---
+description: 从命令行运行 httptap，并读取任意 HTTP 请求的各阶段计时明细。
+---
+
+# 基础用法
+
+## 命令行界面
+
+`httptap` 命令行界面提供了多种选项，用于自定义你的 HTTP 请求和输出。
+
+## 语法
+
+```bash
+httptap [OPTIONS] URL
+```
+
+## 选项
+
+> **兼容 curl：** 常见的 curl 参数可作为别名接受。将 `curl` 替换为 `httptap`，并继续使用你熟悉的选项，如 `-X/--request`、`-L/--location`、`-m/--max-time`、`-k/--insecure`、`-x` 以及 `--http1.1`。这并非完整的 curl 克隆——请只使用此处列出的共有参数。
+
+### 请求选项
+
+#### `-X, --request, --method METHOD`
+
+指定要使用的 HTTP 方法。支持的方法：GET、POST、PUT、PATCH、DELETE、HEAD、OPTIONS。
+
+*兼容 curl 的别名：* `-X`、`--request`。
+
+```bash
+httptap --method POST https://httpbin.io/post
+```
+
+**默认行为：**
+- 未提供 `--data`：默认为 GET
+- 提供了 `--data` 但没有 `--method`：自动切换为 POST（类似 curl）
+- 显式指定 `--method`：遵循所指定的方法
+
+#### `-d, --data DATA`
+
+发送请求体数据。可以是内联字符串，也可以使用 `@filename` 语法引用文件。
+
+**内联 JSON 数据：**
+```bash
+httptap --data '{"name": "John", "email": "john@example.com"}' https://httpbin.io/post
+```
+
+**从文件加载：**
+```bash
+httptap --data @payload.json https://httpbin.io/post
+```
+
+**自动检测：**
+- 自动检测 Content-Type（JSON、XML、纯文本）
+- 首先检查文件扩展名（.json、.xml、.txt）
+- 回退到 JSON 校验
+
+**不同方法的示例：**
+```bash
+# POST（存在 --data 时自动检测）
+httptap --data '{"key": "value"}' https://httpbin.io/post
+
+# PUT
+httptap --method PUT --data '{"status": "updated"}' https://httpbin.io/put
+
+# PATCH
+httptap --method PATCH --data '{"field": "modified"}' https://httpbin.io/patch
+
+# 带请求体的显式 GET（不常见，会触发警告）
+httptap --method GET --data 'query-data' https://httpbin.io/get
+```
+
+#### `-H, --header`
+
+为请求添加自定义 HTTP 请求头。可多次使用。
+
+```bash
+httptap -H "Accept: application/json" https://httpbin.io
+```
+
+```bash
+httptap \
+  -H "User-Agent: MyApp/1.0" \
+  -H "Authorization: Bearer token123" \
+  https://httpbin.io/bearer
+```
+
+#### `-L, --location, --follow`
+
+跟随 HTTP 重定向，并显示链中每一步的计时（最多 10 次重定向）。
+
+*兼容 curl 的别名：* `-L`、`--location`。
+
+```bash
+httptap --follow https://httpbin.io/redirect/3
+```
+
+默认情况下，httptap 不会跟随重定向，会在第一个重定向响应（3xx 状态码）处停止。
+
+#### `-m, --max-time, --timeout SECONDS`
+
+如果总耗时超过指定的秒数，则中止请求链。
+
+*兼容 curl 的别名：* `-m`、`--max-time`。
+
+```bash
+httptap --timeout 10 https://httpbin.io/delay/2
+```
+
+默认超时为 20 秒。
+
+#### `--no-http2` / `--http1.1`
+
+禁用 HTTP/2 协商并强制使用 HTTP/1.1 连接。
+
+```bash
+httptap --no-http2 https://httpbin.io
+```
+
+默认情况下，如果服务器支持则启用 HTTP/2。
+
+*兼容 curl 的别名：* `--http1.1`。
+
+#### `-k, --insecure, --ignore-ssl`
+
+禁用 TLS 证书校验。适用于调试自签名主机或已过期的证书。
+
+```bash
+httptap --ignore-ssl https://self-signed.badssl.com
+```
+
+!!! warning
+    请仅在可信网络中使用此选项。它会禁用证书校验并放宽握手约束。
+
+*兼容 curl 的别名：* `-k`、`--insecure`。
+
+#### `-x, --proxy URL`
+
+通过指定的代理转发请求。支持 HTTP、HTTPS、SOCKS5 和 SOCKS5H 协议。
+
+*兼容 curl 的别名：* `-x`。
+
+```bash
+# HTTP 代理
+httptap --proxy http://proxy.local:8080 https://httpbin.io/get
+
+# SOCKS5 代理（由代理解析 DNS）
+httptap --proxy socks5h://proxy.local:1080 https://httpbin.io/get
+
+# SOCKS5 代理（本地解析 DNS）
+httptap --proxy socks5://proxy.local:1080 https://httpbin.io/get
+
+# 忽略代理环境变量并直连
+httptap --proxy "" https://httpbin.io/get
+```
+
+`--proxy` 参数优先于环境变量（`HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY`）。使用 `--proxy ""` 可忽略所有代理环境变量并直连。有关代理协议、DNS 解析和环境变量配置的详细信息，请参见 [高级功能](advanced.md#using-proxies)。
+
+#### `--cacert, --ca-bundle PATH`
+
+使用自定义 CA 证书包（PEM 格式）进行 TLS 校验。适用于由私有 CA 签名的内部端点。
+
+```bash
+httptap --cacert ~/certs/company-ca.pem https://internal-api.example.com/health
+```
+
+与 `--ignore-ssl` 互斥。
+
+### 输出选项
+
+#### `--compact`
+
+以紧凑的单行格式显示结果，适合日志记录。
+
+```bash
+httptap --compact https://httpbin.io/get
+```
+
+输出：
+
+```
+Step 1: 200 GET https://httpbin.io/get | dns=8.9ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=447.3ms | 389 B
+```
+
+`--compact` 为每一步打印一行人类可读的信息（适合日志和重定向链追踪），同时仍会渲染分析头部和 `Redirect Chain Summary` 表格。响应大小会以适当的单位（`B`、`KB`、`MB`）显示。若需机器可解析的输出，请参见 `--metrics-only`。
+
+#### `--metrics-only`
+
+输出未经格式化的原始指标，非常适合脚本化和自动化。
+
+```bash
+httptap --metrics-only https://httpbin.io
+```
+
+输出：
+
+```
+Step 1: dns=30.1 connect=97.3 tls=199.0 ttfb=472.2 total=476.0 status=200 bytes=389 ip=44.211.11.205 family=IPv4 tls_version=TLSv1.2 proxy=direct
+```
+
+#### `--json PATH`
+
+将完整的请求数据导出到 JSON 文件。
+
+```bash
+httptap --json report.json https://httpbin.io
+```
+
+该 JSON 文件包含：
+
+- 所有阶段的计时明细
+- 网络信息（IP 地址、TLS 详情、证书信息）
+- 响应元数据（状态、请求头、响应体大小）
+- 完整的重定向链（使用 `--follow` 时）
+- SLO 评估（提供 `--slo` 时）
+
+#### `--slo KEY=MS[,KEY=MS...]`
+
+根据各阶段的延迟预算校验最终成功的步骤。发生违规时 `httptap` 仍会渲染完整报告，但会以代码 `4` 退出，以便该结果可作为 CI 任务、cron 探针或 Kubernetes 就绪检查的门禁。
+
+```bash
+httptap --slo total=500,ttfb=200 https://httpbin.io/get
+```
+
+支持的键：`dns`、`connect`、`tls`、`ttfb`、`wait`、`xfer`、`total`。有关完整规范、退出码优先级以及 CI/cron 实用示例，请参见专门的 [SLO 阈值校验](slo.md) 页面。
+
+#### `--version`
+
+显示 httptap 版本并退出。
+
+```bash
+httptap --version
+```
+
+## HTTP 方法
+
+httptap 支持所有标准 HTTP 方法：
+
+- **GET** —— 获取资源（未提供 `--data` 时的默认方法）
+- **POST** —— 创建/提交资源（提供 `--data` 时自动选用）
+- **PUT** —— 替换资源
+- **PATCH** —— 部分更新资源
+- **DELETE** —— 删除资源
+- **HEAD** —— 仅获取请求头
+- **OPTIONS** —— 查询允许的方法
+
+### 方法选择逻辑
+
+1. **显式方法：** `--method` 始终优先
+2. **自动 POST：** 存在 `--data` 而没有 `--method` 时，默认为 POST
+3. **默认 GET：** 未提供 `--data` 或 `--method` 时，使用 GET
+
+### 按使用场景分类的示例
+
+**API 测试：**
+```bash
+# 创建资源
+httptap --data '{"title": "New Post"}' https://httpbin.io/post
+
+# 更新资源
+httptap --method PUT --data '{"title": "Updated"}' https://httpbin.io/put
+
+# 部分更新
+httptap --method PATCH --data '{"status": "published"}' https://httpbin.io/patch
+
+# 删除资源
+httptap --method DELETE https://httpbin.io/delete
+```
+
+**健康检查：**
+```bash
+# 快速检查（仅请求头）
+httptap --method HEAD https://httpbin.io/status/200
+
+# 完整响应
+httptap https://httpbin.io/status/200
+```
+
+## 请求流程
+
+每次 httptap 请求都会经历以下阶段：
+
+1. **DNS 解析** —— 域名查找
+2. **TCP 连接** —— 建立 TCP 连接
+3. **TLS 握手** —— 协商安全连接（仅 HTTPS）
+4. **服务器等待** —— 从请求发出到收到第一个响应字节之间的时间
+5. **响应体传输** —— 下载响应体
+
+## 理解输出
+
+### 丰富模式（默认）
+
+默认的丰富输出会显示一个瀑布图表格，包含：
+
+- 阶段名称和持续时间
+- 可视化进度条
+- 网络详情（IP、TLS 版本、证书信息）
+- 响应元数据（状态、大小、content-type）
+
+### 计时明细
+
+- **DNS (ms)** —— 将域名解析为 IP 地址的时间
+- **Connect (ms)** —— 建立 TCP 连接的时间
+- **TLS (ms)** —— TLS 握手的时间（仅 HTTPS）
+- **TTFB (ms)** —— 首字节时间（包含服务器处理）
+- **Transfer (ms)** —— 下载响应体的时间
+- **Total (ms)** —— 端到端的请求耗时
+
+### 网络信息
+
+- **IP 地址** —— 解析出的 IP 地址及其地址族（IPv4/IPv6）
+- **TLS 版本** —— 协议版本（TLS 1.2、TLS 1.3）
+- **加密套件** —— 协商出的加密套件
+- **证书 CN** —— 服务器证书中的通用名称（Common Name）
+- **证书到期** —— 证书到期前的剩余天数
+
+## 示例
+
+### 基础健康检查
+
+```bash
+httptap https://httpbin.io/status/200
+```
+
+### 带认证的 API 请求
+
+```bash
+httptap \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -H "Accept: application/json" \
+  https://httpbin.io/bearer
+```
+
+### 跟随重定向链
+
+```bash
+httptap --follow https://httpbin.io/redirect/3
+```
+
+### 导出以供分析
+
+```bash
+httptap --json analysis.json --follow https://httpbin.io/redirect/2
+```
+
+### 记录到文件
+
+```bash
+httptap --metrics-only https://httpbin.io/delay/1 >> api-latency.log
+```
+
+---
+
+## 接下来做什么？
+
+<div class="grid cards" markdown>
+
+-   :material-palette:{ .lg .middle } **[输出格式](output-formats.md)**
+
+    ---
+
+    丰富、紧凑、JSON 和指标模式
+
+-   :material-cog:{ .lg .middle } **[高级功能](advanced.md)**
+
+    ---
+
+    自定义组件与编程用法
+
+-   :material-api:{ .lg .middle } **[API 参考](../api/overview.md)**
+
+    ---
+
+    使用协议扩展 httptap
+
+</div>

--- a/docs/usage/output-formats.md
+++ b/docs/usage/output-formats.md
@@ -1,3 +1,7 @@
+---
+description: Choose between rich, compact, metrics-only, and JSON output modes to suit debugging or automation.
+---
+
 # Output Formats
 
 httptap supports multiple output formats to suit different use cases, from interactive troubleshooting to automated
@@ -115,6 +119,11 @@ httptap --json output.json https://httpbin.io
     {
       "url": "https://httpbin.io",
       "step_number": 1,
+      "request": {
+        "method": "GET",
+        "headers": {},
+        "body_bytes": 0
+      },
       "timing": {
         "dns_ms": 8.947,
         "connect_ms": 96.977,
@@ -150,10 +159,15 @@ httptap --json output.json https://httpbin.io
         "server": null,
         "date": "2025-10-23T19:20:36+00:00",
         "location": null,
-        "headers": {}
+        "headers": {
+          "date": "Thu, 23 Oct 2025 19:20:36 GMT",
+          "content-type": "application/json",
+          "server": "gunicorn/19.9.0"
+        }
       },
       "error": null,
-      "note": null
+      "note": null,
+      "proxy": null
     }
   ],
   "summary": {

--- a/docs/usage/output-formats.zh.md
+++ b/docs/usage/output-formats.zh.md
@@ -1,0 +1,295 @@
+---
+description: 在丰富、紧凑、仅指标和 JSON 输出模式之间选择，以适应调试或自动化场景。
+---
+
+# 输出格式
+
+httptap 支持多种输出格式，以适应从交互式故障排查到自动化脚本化的不同使用场景。
+
+## 丰富模式（默认）
+
+默认的输出格式使用 [Rich](https://github.com/Textualize/rich) 库在你的终端中显示一个精美的瀑布图表格。
+
+```bash
+httptap https://httpbin.io
+```
+
+### 特性
+
+- **带语法高亮的彩色输出**
+- **计时阶段的可视化进度条**
+- **便于阅读的结构化表格**
+- **网络详情**，包括 IP、TLS 版本和证书信息
+- **响应元数据**，显示状态、请求头和响应体大小
+
+### 何时使用
+
+- 交互式调试会话
+- 请求性能的可视化检查
+- 向利益相关者展示计时数据
+
+## 紧凑模式
+
+每一步一行人类可读的信息，专为终端日志和重定向链追踪而设计。
+
+```bash
+httptap --compact https://httpbin.io/get
+```
+
+### 示例输出
+
+```
+Step 1: 200 GET https://httpbin.io/get | dns=8.9ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=447.3ms | 389 B
+```
+
+### 特性
+
+- **每步单行** —— 先是 HTTP 状态，然后是方法和 URL，再是各阶段计时，最后是人类可读的响应体大小。
+- **计时带 `ms` 后缀**，因此与散文式日志条目并排时读起来更自然。
+- **响应大小**会以适当的单位（`B`、`KB`、`MB`）格式化。
+- **重定向摘要表格**仍会在各步骤行之后打印，以便整条链的整体形态保持可见。
+
+### 何时使用
+
+- 追加到日志文件
+- 快速的性能比较
+- CI / CD 流水线输出，同时你仍希望看到 URL 和状态
+- 当完整瀑布图过于嘈杂时的终端友好摘要
+
+## 仅指标模式
+
+未经格式化的原始指标，为其他工具的解析而优化。
+
+```bash
+httptap --metrics-only https://httpbin.io
+```
+
+### 示例输出
+
+```
+Step 1: dns=30.1 connect=97.3 tls=199.0 ttfb=472.2 total=476.0 status=200 bytes=389 ip=44.211.11.205 family=IPv4 tls_version=TLSv1.2 proxy=direct
+```
+
+### 特性
+
+- **机器可解析**的格式
+- **完整指标**，包括网络详情
+- **一致的结构**，便于提取
+- **无颜色或格式化**字符
+
+### 何时使用
+
+- 脚本化和自动化
+- 用于分析的数据采集
+- 与监控工具集成
+- 使用 awk/grep/sed 解析
+
+### 解析示例
+
+```bash
+# 提取 TTFB 值
+httptap --metrics-only https://httpbin.io/delay/1 | grep -oP 'ttfb=\K[0-9.]+'
+
+# 获取所有计时指标
+httptap --metrics-only https://httpbin.io/get | \
+  awk '{for(i=1;i<=NF;i++){if($i ~ /=/) print $i}}'
+```
+
+## JSON 导出
+
+将完整的请求数据导出为结构化 JSON，以便进行全面分析。
+
+```bash
+httptap --json output.json https://httpbin.io
+```
+
+### JSON 结构
+
+```json
+{
+  "initial_url": "https://httpbin.io",
+  "total_steps": 1,
+  "steps": [
+    {
+      "url": "https://httpbin.io",
+      "step_number": 1,
+      "request": {
+        "method": "GET",
+        "headers": {},
+        "body_bytes": 0
+      },
+      "timing": {
+        "dns_ms": 8.947,
+        "connect_ms": 96.977,
+        "tls_ms": 194.566,
+        "ttfb_ms": 445.951,
+        "total_ms": 447.344,
+        "wait_ms": 145.461,
+        "xfer_ms": 1.392,
+        "is_estimated": false
+      },
+      "network": {
+        "ip": "44.211.11.205",
+        "ip_family": "IPv4",
+        "http_version": "HTTP/2.0",
+        "tls_version": "TLSv1.2",
+        "tls_cipher": "ECDHE-RSA-AES128-GCM-SHA256",
+        "cert_cn": "httpbin.io",
+        "cert_days_left": 143,
+        "cert_sans": ["httpbin.io", "*.httpbin.io"],
+        "cert_issuer": "WE1",
+        "cert_serial": "05BB0F0AA84C8FECE0E72D805BA7A5D2B",
+        "cert_not_before": "2025-04-01T00:00:00+00:00",
+        "cert_not_after": "2025-09-01T00:00:00+00:00",
+        "tls_verified": true,
+        "tls_custom_ca": null,
+        "proxy_url": null,
+        "proxy_source": null
+      },
+      "response": {
+        "status": 200,
+        "bytes": 389,
+        "content_type": "application/json",
+        "server": null,
+        "date": "2025-10-23T19:20:36+00:00",
+        "location": null,
+        "headers": {
+          "date": "Thu, 23 Oct 2025 19:20:36 GMT",
+          "content-type": "application/json",
+          "server": "gunicorn/19.9.0"
+        }
+      },
+      "error": null,
+      "note": null,
+      "proxy": null
+    }
+  ],
+  "summary": {
+    "total_time_ms": 447.344,
+    "final_status": 200,
+    "final_url": "https://httpbin.io",
+    "final_bytes": 389,
+    "errors": 0
+  }
+}
+```
+
+### 特性
+
+- **所有阶段的完整数据导出**
+- **结构化格式**，便于解析
+- **重定向链支持**，包含多个步骤
+- **元数据保留**（请求头、时间戳）
+- **错误信息**（请求失败时）
+
+### 何时使用
+
+- 后处理分析
+- 与数据管道集成
+- 长期性能跟踪
+- 详细的调试会话
+- 与团队成员共享结果
+
+### 处理示例
+
+使用 `jq` 提取特定字段：
+
+```bash
+# 获取总时间
+jq '.summary.total_time_ms' output.json
+
+# 提取所有 TTFB 值
+jq '.steps[].timing.ttfb_ms' output.json
+
+# 获取证书到期信息
+jq '.steps[0].network.cert_days_left' output.json
+
+# 筛选失败的请求
+jq 'select(.summary.errors > 0)' output.json
+```
+
+## 重定向链
+
+使用 `--follow` 时，所有输出格式都会包含重定向链中每一步的数据。
+
+### 丰富模式
+
+显示一个包含整条链合计值的摘要表格。
+
+```bash
+httptap --follow https://httpbin.io/redirect/3
+```
+
+### 紧凑模式
+
+每个重定向步骤输出一行，随后是重定向链摘要表格。
+
+```bash
+httptap --follow --compact https://httpbin.io/redirect/2
+```
+
+输出：
+
+```
+Step 1: 302 GET https://httpbin.io/redirect/2 | dns=8.9ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=447.3ms | 0 B
+Step 2: 302 GET https://httpbin.io/relative-redirect/1 | dns=2.7ms connect=97.5ms tls=194.0ms ttfb=400.2ms total=400.6ms | 0 B
+Step 3: 200 GET https://httpbin.io/get | dns=2.6ms connect=97.4ms tls=197.3ms ttfb=403.2ms total=404.0ms | 389 B
+```
+
+### JSON 导出
+
+在 `steps` 数组中包含所有步骤，附带完整的计时和元数据。
+
+```bash
+httptap --follow --json redirect-chain.json https://httpbin.io/redirect/3
+```
+
+## 组合选项
+
+输出格式选项可与其他参数组合使用：
+
+```bash
+# 跟随重定向并使用紧凑输出
+httptap --follow --compact https://httpbin.io/redirect/2
+
+# 将重定向链导出为 JSON 并显示指标
+httptap --follow --json chain.json --metrics-only https://bit.ly/example
+```
+
+!!! note
+    当 `--json` 与显示模式（`--compact`、`--metrics-only`）同时使用时，显示模式会输出到 stdout，而 JSON 会写入文件。
+
+---
+
+## SLO 阈值叠加
+
+`--slo KEY=MS[,KEY=MS...]` 会为每种输出模式增加一个通过/失败的判定，该判定针对最终成功的请求进行评估。
+
+- **丰富模式** —— 瀑布图后会打印一个带边框的面板。通过时边框为绿色，失败时为红色，且每个违规项都会以毫秒列出实际值、阈值和超出量。
+- **紧凑模式** —— 行为与上述丰富模式相同；SLO 面板仍会在单行步骤摘要之后打印。
+- **仅指标** —— 最终成功步骤的那一行会新增 `slo=pass` 或 `slo=fail slo_violations=<keys>` 标记。中间的重定向步骤保持不变。
+- **JSON** —— `summary.slo` 包含 `pass`、`thresholds_ms` 以及 `violations[]`（每项带有 `key`、`threshold_ms`、`actual_ms`、`delta_ms`）。未提供 `--slo` 时不存在此块。
+
+发生违规会使 `httptap` 以代码 `4` 退出，同时仍渲染完整输出，从而为事后复盘保留证据。
+
+有关规范语法、评估规则、退出码优先级以及 CI / cron 实用示例，请参见专门的 [SLO 阈值校验](slo.md) 页面。
+
+---
+
+## 接下来做什么？
+
+<div class="grid cards" markdown>
+
+-   :material-cog:{ .lg .middle } **[高级功能](advanced.md)**
+
+    ---
+
+    自定义组件、监控、批量分析
+
+-   :material-api:{ .lg .middle } **[API 参考](../api/overview.md)**
+
+    ---
+
+    编程用法与扩展
+
+</div>

--- a/docs/usage/slo.md
+++ b/docs/usage/slo.md
@@ -104,7 +104,7 @@ summarising the SLO evaluation:
 │ Thresholds: total≤500ms, ttfb≤200ms            │
 │ Violations:                                    │
 │   • total: 723.4ms > 500ms (+223.4ms)          │
-│   • ttfb:  315.2ms > 200ms (+115.2ms)          │
+│   • ttfb: 315.2ms > 200ms (+115.2ms)          │
 ╰────────────────────────────────────────────────╯
 ```
 

--- a/docs/usage/slo.zh.md
+++ b/docs/usage/slo.zh.md
@@ -1,0 +1,226 @@
+---
+title: SLO 阈值校验
+description: 使用 --slo 依据各阶段延迟预算，在 CI、cron 和就绪检查中对请求进行门禁校验。
+---
+
+# SLO 阈值校验
+
+`httptap --slo` 会将测量到的计时与各阶段延迟预算进行比对，当任一预算被超出时以非零码退出。这将一次请求变成一个通过/失败的探针，适用于 CI 门禁、基于 cron 的合成监控、就绪检查以及部署后的冒烟测试——无需编写自定义的 shell 解析器。
+
+## 快速示例
+
+```shell
+httptap --slo total=500,ttfb=200 https://api.example.com/health
+```
+
+- 当 `total_ms ≤ 500` **且** `ttfb_ms ≤ 200` 时以 `0` 退出。
+- 当任一预算被超出时以 `4` 退出。
+- 无论结果如何，都会继续打印完整的瀑布图和 JSON 导出，因此排查工作绝不会被门禁阻断。
+
+## 规范语法
+
+向 `--slo` 传入一个逗号分隔的 `KEY=MS` 对列表：
+
+```
+--slo KEY=MS[,KEY=MS]*
+```
+
+- `KEY` 是受支持的计时阶段之一（不区分大小写）。
+- `MS` 是一个正的有限毫秒数（整数或浮点数）。
+- 键和值周围的空白字符会被容忍。
+
+### 支持的键
+
+| Key       | Meaning                                                        |
+|-----------|----------------------------------------------------------------|
+| `dns`     | DNS 解析时间                                                    |
+| `connect` | TCP 连接建立                                                    |
+| `tls`     | TLS 握手（纯 HTTP 时为 `0`）                                     |
+| `ttfb`    | 首字节时间（DNS + connect + TLS + 服务器等待）                    |
+| `wait`    | 服务器处理时间（`ttfb - (dns + connect + tls)`）                 |
+| `xfer`    | 响应体传输时间（`total - ttfb`）                                 |
+| `total`   | 端到端请求耗时                                                  |
+
+### 格式错误的规范
+
+`--slo` 会拒绝以下情况并以 `64`（用法错误）退出：
+
+- 空规范（`--slo ""`）。
+- 未知键（`--slo foo=500` → `Unknown SLO key 'foo'`）。
+- 重复键（`--slo total=500,total=600`）。
+- 非数值（`--slo total=fast`）。
+- 零、负值或非有限值（`--slo total=0`、`total=nan`、`total=inf`）。
+- 缺少 `=`（`--slo total500`）。
+
+具体错误会在 Rich 格式的面板中打印以供交互使用，并在 `--metrics-only` 下以纯文本打印。
+
+## 评估规则
+
+SLO 阈值针对请求链的**最终成功步骤**进行评估：
+
+- 单次请求 → 针对该请求进行校验。
+- 重定向链（`--follow`）→ 针对最终响应而非中间的重定向进行校验。其假设是用户关心的是实际为其请求提供服务的那个响应。
+- 所有步骤均出错 → 完全跳过 SLO；退出码反映网络故障（见下文）。
+
+当 `actual ≤ threshold` 时阈值通过。相等**不**计为违规。违规项会按其键的字母顺序报告，以获得确定性的输出。
+
+## 退出码
+
+`--slo` 与 `httptap` 的整体退出码优先级相集成：
+
+| Priority | Condition                               | Exit code |
+|:--------:|-----------------------------------------|:---------:|
+| 1        | 参数无效（`--slo` 规范错误）             | `64`      |
+| 2        | 任一步骤上的网络 / TLS 故障              | `75`      |
+| 3        | 内部错误                                | `70`      |
+| 4        | 最终成功步骤上的 SLO 违规               | `4`       |
+| 5        | 成功                                    | `0`       |
+
+网络错误始终优先于 SLO 违规，因此故障的主机不会在 CI 日志中伪装成延迟回归。
+
+## 输出格式
+
+### Rich（默认）
+
+在瀑布图和任何重定向摘要之后，`httptap` 会打印一个总结 SLO 评估的面板：
+
+```
+╭───────────────── ✗ SLO: fail ─────────────────╮
+│ Thresholds: total≤500ms, ttfb≤200ms            │
+│ Violations:                                    │
+│   • total: 723.4ms > 500ms (+223.4ms)          │
+│   • ttfb: 315.2ms > 200ms (+115.2ms)          │
+╰────────────────────────────────────────────────╯
+```
+
+面板边框和图标与状态匹配：通过时为绿色 `✓`，失败时为红色 `✗`。
+
+### 紧凑
+
+`--compact` 会为每个步骤打印一行人类可读的信息，随后是与默认模式下相同的 Rich SLO 面板：
+
+```
+Step 1: 200 GET https://api.example.com | dns=3.3ms connect=97.0ms tls=194.6ms ttfb=446.0ms total=900.0ms | 1.2 KB
+
+╭───────────────── ✗ SLO: fail ─────────────────╮
+│ Thresholds: total≤500ms                        │
+│ Violations:                                    │
+│   • total: 900.0ms > 500ms (+400.0ms)          │
+╰────────────────────────────────────────────────╯
+```
+
+### 仅指标
+
+`--metrics-only` 会将 SLO 标记追加到最终成功步骤的标准 `key=value` 行：
+
+```
+Step 1: dns=30.1 connect=97.3 tls=199.0 ttfb=472.2 total=900.0 ... slo=fail slo_violations=total,ttfb
+```
+
+通过的情况：
+
+```
+Step 1: ... proxy=direct slo=pass
+```
+
+中间的重定向步骤**不**携带 SLO 标记，从而保持行数不变。
+
+### JSON 导出
+
+`--json PATH` 会用一个 `slo` 对象扩展 `summary` 块：
+
+```json
+{
+  "summary": {
+    "total_time_ms": 900.0,
+    "final_status": 200,
+    "final_url": "https://api.example.com/health",
+    "final_bytes": 128,
+    "errors": 0,
+    "slo": {
+      "pass": false,
+      "thresholds_ms": { "total": 500.0, "ttfb": 200.0 },
+      "violations": [
+        {
+          "key": "total",
+          "threshold_ms": 500.0,
+          "actual_ms": 900.0,
+          "delta_ms": 400.0
+        }
+      ]
+    }
+  }
+}
+```
+
+每个违规项都携带键、用户提供的阈值、测量值以及超出量。`delta_ms` 严格为正，可用于按严重程度对违规项进行排序。
+
+当未传入 `--slo` 参数时，`slo` 键将不存在——摘要的结构与现有的消费者保持向后兼容。
+
+## 实用示例
+
+### 基于 cron 的合成监控
+
+```cron
+* * * * * httptap --slo total=1000,ttfb=500 https://api.example.com/health \
+  || curl -X POST https://alerts.example.com/page/oncall
+```
+
+### 部署后的 CI 门禁
+
+```yaml
+- name: Smoke-test staging latency
+  run: |
+    httptap --slo total=2000,tls=300,ttfb=800 \
+      https://staging.example.com/
+```
+
+该步骤仅在退出码 `4` 或 `64` 时失败。网络错误（退出码 `75`）可以单独处理：
+
+```yaml
+- name: Smoke-test staging latency
+  id: smoke
+  continue-on-error: true
+  run: httptap --slo total=2000 https://staging.example.com/
+- name: Fail CI only on SLO violation
+  if: steps.smoke.outcome == 'failure' && steps.smoke.conclusion != 'success'
+  run: |
+    if [ "${{ steps.smoke.outputs.exit_code }}" = "4" ]; then
+      echo "SLO violation — failing build."
+      exit 1
+    fi
+```
+
+### Kubernetes 就绪探针
+
+```yaml
+readinessProbe:
+  exec:
+    command:
+      - httptap
+      - --slo
+      - total=5000
+      - http://localhost:8080/healthz
+```
+
+### 回归门槛
+
+```shell
+httptap --slo total=500,ttfb=200 --json regression.json https://prod.example.com/
+jq '.summary.slo.violations' regression.json
+```
+
+### 多主机金丝雀
+
+```shell
+for host in prod-eu prod-us prod-ap; do
+  httptap --slo total=1500 "https://${host}.example.com/health" || echo "${host}: SLO miss"
+done
+```
+
+## 提示
+
+- 先从 `--slo total=<P95 latency>` 开始，待你从 `--json` 导出获得基线数据后，再添加各阶段的预算。
+- `xfer` 和 `wait` 是派生指标；它们的总和以 `total` 为上界。如果你设置了 `total` 预算，各个阶段就被隐式地设了上限。
+- 与 `--timeout` 结合使用：`--slo` 在请求完成*之后*校验延迟；`--timeout` 会硬性终止一个挂起的请求。你通常两者都需要。
+- SLO 输出与 [`httpstat` 的 `--slo`](https://github.com/reorx/httpstat#slo-thresholds) 格式一致（`slo=pass` / `slo=fail` 标记，退出码 `4`），因此脚本可以互换使用。

--- a/httptap/implementations/dns.py
+++ b/httptap/implementations/dns.py
@@ -53,16 +53,43 @@ def _extract_sockaddr(entry: Iterable[Any]) -> tuple[Any, ...]:
 
 
 class DNSResolutionError(Exception):
-    """Raised when DNS resolution fails."""
+    """Raised when DNS resolution fails.
+
+    Signals that a hostname could not be resolved to an IP address, whether
+    due to a lookup failure, a timeout, or an empty address list. Wraps the
+    originating ``socket`` error where one is available.
+    """
 
 
 class SystemDNSResolver:
-    """DNS resolver using the system getaddrinfo implementation."""
+    """DNS resolver using the system getaddrinfo implementation.
+
+    Resolves hostnames with :func:`socket.getaddrinfo` on a background thread so
+    the lookup can be bounded by a timeout. It implements the
+    :class:`~httptap.interfaces.DNSResolver` protocol and is the default resolver
+    used by the analyzer.
+    """
 
     __slots__ = ()
 
     def resolve(self, host: str, port: int, timeout: float) -> tuple[str, str, float]:
-        """Resolve host and return IP, family label, and elapsed milliseconds."""
+        """Resolve host and return IP, family label, and elapsed milliseconds.
+
+        Args:
+            host: Hostname to resolve (e.g., "example.com").
+            port: Port number used to hint the address lookup.
+            timeout: Maximum time to wait for resolution, in seconds.
+
+        Returns:
+            Tuple of ``(ip_address, ip_family, elapsed_ms)`` where ``ip_family``
+            is one of ``"IPv4"``, ``"IPv6"``, or ``"AF_<num>"`` for other
+            address families, and ``elapsed_ms`` is the resolution time in
+            milliseconds.
+
+        Raises:
+            DNSResolutionError: If resolution times out, the lookup fails, or no
+                usable address record is returned.
+        """
         start_time = time.perf_counter()
 
         addr_info: list[AddrInfo] | None = None

--- a/httptap/implementations/timing.py
+++ b/httptap/implementations/timing.py
@@ -9,7 +9,13 @@ from httptap.models import TimingMetrics
 
 
 class PerfCounterTimingCollector:
-    """High-precision timing collector using time.perf_counter()."""
+    """High-precision timing collector using time.perf_counter().
+
+    Records monotonic timestamps as each request phase is marked and derives
+    DNS, TTFB, and total durations from them. Implements the
+    :class:`~httptap.interfaces.TimingCollector` protocol and is the default
+    collector used by the analyzer. A fresh instance is created per request.
+    """
 
     __slots__ = (
         "_dns_end",
@@ -50,7 +56,13 @@ class PerfCounterTimingCollector:
         self._end_time = time.perf_counter()
 
     def get_metrics(self) -> TimingMetrics:
-        """Build a TimingMetrics instance populated with collected timings."""
+        """Build a TimingMetrics instance populated with collected timings.
+
+        Returns:
+            A TimingMetrics with ``dns_ms``, ``ttfb_ms``, and ``total_ms``
+            computed from the recorded marks. Call ``calculate_derived()`` on
+            the result to populate ``wait_ms`` and ``xfer_ms``.
+        """
         timing = TimingMetrics()
         timing.dns_ms = (self._dns_end - self._dns_start) * MS_IN_SECOND
         timing.total_ms = (self._end_time - self._start_time) * MS_IN_SECOND

--- a/httptap/implementations/tls.py
+++ b/httptap/implementations/tls.py
@@ -12,11 +12,23 @@ from httptap.utils import create_ssl_context
 
 
 class TLSInspectionError(Exception):
-    """Raised when TLS inspection fails."""
+    """Raised when TLS inspection fails.
+
+    Signals that a dedicated TLS probe could not complete, for example because
+    the TCP connection failed or the TLS handshake could not be established.
+    Wraps the originating exception as its cause.
+    """
 
 
 class SocketTLSInspector:
-    """TLS inspector that performs a dedicated TLS handshake using ``ssl``."""
+    """TLS inspector that performs a dedicated TLS handshake using ``ssl``.
+
+    Opens a short-lived TCP connection, performs a TLS handshake, and extracts
+    the negotiated version, cipher suite, and leaf-certificate details into a
+    :class:`~httptap.models.NetworkInfo`. Implements the
+    :class:`~httptap.interfaces.TLSInspector` protocol and is the default
+    inspector used by the analyzer.
+    """
 
     __slots__ = ("_ca_bundle_path", "_verify")
 
@@ -33,7 +45,21 @@ class SocketTLSInspector:
         self._ca_bundle_path = ca_bundle_path
 
     def inspect(self, host: str, port: int, timeout: float) -> NetworkInfo:
-        """Inspect TLS connection and extract metadata."""
+        """Inspect TLS connection and extract metadata.
+
+        Args:
+            host: Hostname to connect to, also used for SNI.
+            port: Port number (typically 443 for HTTPS).
+            timeout: Connection timeout in seconds. The probe is additionally
+                capped by ``TLS_PROBE_MAX_TIMEOUT_SECONDS``.
+
+        Returns:
+            A NetworkInfo populated with the resolved IP, negotiated TLS
+            version and cipher, and leaf-certificate details when available.
+
+        Raises:
+            TLSInspectionError: If the connection or TLS handshake fails.
+        """
         network_info = NetworkInfo()
         network_info.tls_verified = self._verify
         probe_timeout = min(timeout, TLS_PROBE_MAX_TIMEOUT_SECONDS)

--- a/httptap/request_executor.py
+++ b/httptap/request_executor.py
@@ -29,7 +29,32 @@ if TYPE_CHECKING:
 
 @dataclass(slots=True)
 class RequestOptions:
-    """Aggregates all parameters required to perform a single HTTP request."""
+    """Aggregates all parameters required to perform a single HTTP request.
+
+    Attributes:
+        url: Target URL to request. Must be a valid HTTP/HTTPS URL.
+        timeout: Request timeout in seconds.
+        method: HTTP method to use for the request.
+        content: Optional request body as bytes.
+        http2: Whether to enable HTTP/2 support.
+        verify_ssl: Whether to verify TLS certificates.
+        ca_bundle_path: Path to a custom CA certificate bundle (PEM format).
+            Only used when verify_ssl is True. If None, the system CA bundle
+            is used.
+        dns_resolver: Custom DNS resolver implementation. If None, the executor
+            uses its default resolver.
+        tls_inspector: Custom TLS inspector implementation. If None, the executor
+            uses its default inspector.
+        timing_collector: Timing collector instance used to measure request
+            phases. If None, no phase timing is collected for this request.
+        force_new_connection: Whether to force a fresh connection instead of
+            reusing a pooled one, ensuring per-request timing is accurate.
+        headers: Optional mapping of request headers to send.
+        proxy: Optional proxy URL (http/https/socks5/socks5h) applied to the
+            request.
+        noproxy: When True, ignore proxy environment variables and connect
+            directly.
+    """
 
     url: str
     timeout: float
@@ -49,7 +74,13 @@ class RequestOptions:
 
 @dataclass(slots=True)
 class RequestOutcome:
-    """Wraps the collected timing, network, and response objects."""
+    """Wraps the collected timing, network, and response objects.
+
+    Attributes:
+        timing: Timing metrics gathered for the request phases.
+        network: Network and TLS/certificate information for the connection.
+        response: HTTP response metadata (status, headers, body size).
+    """
 
     timing: TimingMetrics
     network: NetworkInfo
@@ -58,19 +89,59 @@ class RequestOutcome:
 
 @runtime_checkable
 class RequestExecutor(Protocol):
-    """Protocol describing modern request executors used by the analyzer."""
+    """Protocol describing modern request executors used by the analyzer.
+
+    Implementations perform a single HTTP request described by a
+    :class:`RequestOptions` instance and return the collected metrics as a
+    :class:`RequestOutcome`. This lets the analyzer delegate the actual
+    transport work to interchangeable backends.
+
+    Examples:
+        >>> class CustomExecutor:
+        ...     def execute(self, options: RequestOptions) -> RequestOutcome:
+        ...         ...  # perform the request and collect metrics
+    """
 
     def execute(self, options: RequestOptions) -> RequestOutcome:
-        """Perform an HTTP request based on provided options."""
+        """Perform an HTTP request based on the provided options.
+
+        Args:
+            options: Fully populated request parameters, including URL,
+                timeout, method, and any injected collaborators.
+
+        Returns:
+            A RequestOutcome bundling the timing, network, and response data.
+
+        Raises:
+            httptap.http_client.HTTPClientError: If the request cannot be
+                completed. Implementations should surface transport failures
+                using this error type so the analyzer can record partial data.
+        """
 
 
 class HTTPClientRequestExecutor:
-    """RequestExecutor that delegates to the built-in http client."""
+    """RequestExecutor that delegates to the built-in HTTP client.
+
+    This is the default executor used by :class:`~httptap.analyzer.HTTPTapAnalyzer`.
+    It forwards each request to :func:`httptap.http_client.make_request`, which
+    instruments DNS, connection, TLS, and transfer timing.
+    """
 
     __slots__ = ()
 
     def execute(self, options: RequestOptions) -> RequestOutcome:
-        """Perform an HTTP request using the default client."""
+        """Perform an HTTP request using the default client.
+
+        Args:
+            options: Fully populated request parameters.
+
+        Returns:
+            A RequestOutcome bundling the timing, network, and response data.
+
+        Raises:
+            httptap.http_client.HTTPClientError: If the underlying HTTP request
+                fails.
+        """
         timing, network, response = make_request(
             options.url,
             options.timeout,

--- a/httptap/visualizer.py
+++ b/httptap/visualizer.py
@@ -14,19 +14,41 @@ from .models import StepMetrics
 
 
 class WaterfallVisualizer(Visualizer):
-    """Creates waterfall diagrams showing request phase timelines."""
+    """Creates waterfall diagrams showing request phase timelines.
+
+    Renders each request phase (DNS, connect, TLS, wait, transfer) as a
+    horizontally offset bar in the terminal using Rich, so the relative cost of
+    each phase is visible at a glance. Implements the
+    :class:`~httptap.interfaces.Visualizer` protocol.
+
+    Attributes:
+        console: Rich console used for output.
+        max_bar_width: Maximum width, in characters, of the timeline bars.
+    """
 
     __slots__ = ("console", "max_bar_width")
 
     BAR_CHAR = "⠿"
 
     def __init__(self, console: Console, max_bar_width: int = 80) -> None:
-        """Configure the visualizer with a console and maximum bar width."""
+        """Configure the visualizer with a console and maximum bar width.
+
+        Args:
+            console: Rich console instance used to print the timeline.
+            max_bar_width: Maximum width, in characters, of the timeline bars.
+        """
         self.console = console
         self.max_bar_width = max_bar_width
 
     def render(self, step: StepMetrics) -> None:
-        """Render a waterfall timeline for the provided step if data is valid."""
+        """Render a waterfall timeline for the provided step if data is valid.
+
+        Steps that errored or have a non-positive total time are skipped and
+        produce no output.
+
+        Args:
+            step: Step metrics containing timing, network, and response data.
+        """
         if step.has_error or step.timing.total_ms <= 0:
             return
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,20 @@ repo_name: ozeranskii/httptap
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2025-2026 Sergei Ozeranskii
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 theme:
   name: material
   custom_dir: docs/overrides
@@ -28,14 +42,16 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.instant
     - navigation.tracking
     - navigation.sections
     - navigation.expand
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share
+    - content.action.edit
+    - content.action.view
     - content.code.copy
     - content.code.annotate
     - content.tabs.link
@@ -56,14 +72,85 @@ extra:
       name: PyPI Package
 
 plugins:
+  - search:
+      separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+  - i18n:
+      docs_structure: suffix
+      reconfigure_material: true
+      reconfigure_search: true
+      languages:
+        - locale: en
+          default: true
+          name: English
+          build: true
+        - locale: zh
+          name: 简体中文
+          build: true
+          site_name: httptap 文档
+          nav_translations:
+            Home: 首页
+            Getting Started: 快速上手
+            Installation: 安装
+            Quick Start: 快速开始
+            Usage: 使用
+            Basic Usage: 基础用法
+            Output Formats: 输出格式
+            SLO Threshold Checking: SLO 阈值检查
+            Advanced Features: 高级功能
+            Troubleshooting & FAQ: 故障排查与常见问题
+            Security: 安全
+            Assurance Case: 保障案例
+            API Reference: API 参考
+            Overview: 概览
+            Core Components: 核心组件
+            Interfaces: 接口
+            Development: 开发
+            Contributing: 贡献指南
+            Release Process: 发布流程
+            About: 关于
+            License: 许可证
+            Changelog: 更新日志
   - social:
       cards: true
       cards_dir: assets/images/social
       cards_layout_options:
         background_color: "#1a1f4b"
         color: "#f5f7ff"
-  - search:
-      separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+      fallback_to_build_date: true
+  - autorefs:
+      resolve_closest: true
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            docstring_section_style: list
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            members_order: source
+            filters:
+              - "!^_"
+            summary: true
+            show_if_no_docstring: false
+            show_source: true
+  - redirects:
+      redirect_maps: {}
+  - minify:
+      minify_html: true
+      htmlmin_opts:
+        remove_comments: true
 
 markdown_extensions:
   # Python Markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ lint = [
 
 docs = [
     "mkdocs-material[imaging]>=9.7.1",
+    "mkdocs-static-i18n>=1.3.1",
+    "mkdocs-git-revision-date-localized-plugin>=1.5.4",
+    "mkdocs-redirects>=1.2.3",
+    "mkdocstrings[python]>=1.0.6",
+    "mkdocs-minify-plugin>=0.8.0",
     "pymdown-extensions>=11.0.2",
 ]
 release = [

--- a/uv.lock
+++ b/uv.lock
@@ -598,6 +598,12 @@ toml = [
 ]
 
 [[package]]
+name = "csscompressor"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
+
+[[package]]
 name = "cssselect2"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -683,6 +689,39 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +750,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
+name = "htmlmin2"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/31/a76f4bfa885f93b8167cb4c85cf32b54d1f64384d0b897d45bc6d19b7b45/htmlmin2-0.1.13-py3-none-any.whl", hash = "sha256:75609f2a42e64f7ce57dbff28a39890363bde9e7e5885db633317efbdf8c79a2", size = 34486, upload-time = "2023-03-14T21:28:30.388Z" },
 ]
 
 [[package]]
@@ -756,7 +803,12 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material", extra = ["imaging"] },
+    { name = "mkdocs-minify-plugin" },
+    { name = "mkdocs-redirects" },
+    { name = "mkdocs-static-i18n" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
 lint = [
@@ -806,7 +858,12 @@ dev = [
     { name = "ruff", specifier = ">=0.16.4" },
 ]
 docs = [
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.4" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7.1" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocs-redirects", specifier = ">=1.2.3" },
+    { name = "mkdocs-static-i18n", specifier = ">=1.3.1" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.6" },
     { name = "pymdown-extensions", specifier = ">=11.0.2" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.16.4" }]
@@ -988,6 +1045,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
+
+[[package]]
+name = "jsmin"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
 
 [[package]]
 name = "librt"
@@ -1268,6 +1331,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1279,6 +1356,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-git-revision-date-localized-plugin"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "gitpython" },
+    { name = "mkdocs" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/43/7c2f67a2ab0f9d2627d52a5a0a12b4206e4468a109ae7a091eeeb45f6825/mkdocs_git_revision_date_localized_plugin-1.5.4.tar.gz", hash = "sha256:07a785522008e881ff4c307e3259ad3ce00931b2d2147a22cdfbb532ff25e4ab", size = 452896, upload-time = "2026-08-21T06:54:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/7c/a19cdb6e1c6f033cd35df847688f99c4f9b80b626fad87483f2069a6dc5a/mkdocs_git_revision_date_localized_plugin-1.5.4-py3-none-any.whl", hash = "sha256:b5e6b4b9e7d169750b6eb078fd91151bc855e65c019a065accce537ec6e69e05", size = 26155, upload-time = "2026-08-21T06:54:45.673Z" },
 ]
 
 [[package]]
@@ -1316,6 +1408,83 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-minify-plugin"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "csscompressor" },
+    { name = "htmlmin2" },
+    { name = "jsmin" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/67/fe4b77e7a8ae7628392e28b14122588beaf6078b53eb91c7ed000fd158ac/mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d", size = 8366, upload-time = "2024-01-29T16:11:32.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/cd/2e8d0d92421916e2ea4ff97f10a544a9bd5588eb747556701c983581df13/mkdocs_minify_plugin-0.8.0-py3-none-any.whl", hash = "sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6", size = 6723, upload-time = "2024-01-29T16:11:31.851Z" },
+]
+
+[[package]]
+name = "mkdocs-redirects"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/25/49725f78ca5d3026b09973f7a2b3a8b179cc2e8c15e43d5a13bc79f6b274/mkdocs_redirects-1.2.3.tar.gz", hash = "sha256:5e980330999299729a2d6a125347d1af78023d68a23681a4de3053ce7dfe2e51", size = 7712, upload-time = "2026-03-28T13:57:41.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/871b1cddc01d2ba1637b858eeeabc2e3013dc8df591306b5567b98ef0870/mkdocs_redirects-1.2.3-py3-none-any.whl", hash = "sha256:ec7312fff462d03ec16395d0c001006a418f8d0c21cdf2b47ff11cf839dc3ce0", size = 6245, upload-time = "2026-03-28T13:57:40.466Z" },
+]
+
+[[package]]
+name = "mkdocs-static-i18n"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f9/51e2ffda9c7210bc35a24f3717b08c052cd4b728dfa87f901c00d8005259/mkdocs_static_i18n-1.3.1.tar.gz", hash = "sha256:a6125ea7db6cc1a900d76a967f262535af09831160a93c56d7f0d522a79b5faf", size = 1371325, upload-time = "2026-02-20T10:42:41.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/0b/43ff4afb6b438d47718b1959a22075ed95d8460d8c47381878b37a40de63/mkdocs_static_i18n-1.3.1-py3-none-any.whl", hash = "sha256:4036e24795a150c9c4d4b001ed24a43aec01335f76188dbe5a5d8fb4a27eba65", size = 21853, upload-time = "2026-02-20T10:42:40.551Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6d/77546d8c26f038fce314a507106954f76270f6c182488bcf9ac9721175df/mkdocstrings_python-2.0.7-py3-none-any.whl", hash = "sha256:1fce5fbfe4ffa6e8136a35351cdc97c3bf55219c7efbd3f92a82260f93235d60", size = 105387, upload-time = "2026-08-17T16:56:16.813Z" },
 ]
 
 [[package]]
@@ -1556,6 +1725,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
+]
+
+[[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
 ]
 
 [[package]]
@@ -1843,6 +2035,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Translates the full documentation site to Simplified Chinese, migrates the API reference to autogenerated docs, and reworks the docs toolchain around a set of MkDocs plugins. English remains the source of truth; the Chinese site is served through i18n fallback where no translation exists.

Fixes # (n/a)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test improvements
- [x] 🔧 Build/CI/tooling changes

## Changes Made

- **i18n:** added `mkdocs-static-i18n` (suffix structure, English default + `zh` fallback) and a Simplified Chinese sibling for every page; nav labels translated via `nav_translations`.
- **API reference → mkdocstrings:** rewrote `docs/api/*` as `:::` autodoc so signatures and defaults come from the source docstrings — this removes drift that had already appeared in the hand-written pages (missing `noproxy`, `proxy_url`/`proxy_source`, `slo_result`). Enriched docstrings in `request_executor`, `implementations/{dns,tls,timing}` and `visualizer` (docstrings only, no behaviour change). Dropped the translated API pages in favour of the English autodoc via i18n fallback; `autorefs.resolve_closest` prevents duplicate-anchor build failures.
- **Plugins & config:** added `git-revision-date-localized`, `redirects`, `minify`; fixed plugin ordering; added a `validation:` block; enabled per-page language switching (removed `navigation.instant`), `content.action.edit`/`view`, footer navigation, and per-page `description` front matter.
- **Accuracy (vs v0.6.0):** corrected the JSON schema (`request` block, `proxy` field, populated response headers), the `NO_PROXY` export value, release step numbering, the docs dependency group in the contributing guide, install recommendations and container tags; documented `argcomplete` shell completion.
- **CI:** the docs workflow now runs a strict build on pull requests and deploys only on `main`. The non-pushing `build` job checks out with `persist-credentials: false` (only the `deploy` job that runs `gh-deploy` keeps the token), matching the repo-wide convention already used by every other workflow.

## Testing

**Test environment:**

- OS: macOS (Darwin 25.5.0)
- Python version: 3.13.7
- httptap version: 0.6.0

**Tests performed:**

- [x] Ran existing test suite: `uv run pytest`
- [ ] Added new tests for new functionality (n/a — documentation and docstring-only changes, no runtime behaviour changed)
- [x] Manually tested with: `httptap <command>` (CLI output cross-checked against the docs during the accuracy pass)
- [x] Tested on multiple OS (if applicable): Linux / macOS / Windows

**Test commands:**

```bash
uv run mkdocs build --strict     # docs build, strict
uv run pytest                    # test suite
uv run ruff check .              # lint
uv run mypy httptap              # types
```

**Expected behavior:**
Docs build cleanly (strict), all existing tests keep passing, and lint/type checks stay green after the docstring edits.

**Actual behavior:**

- `mkdocs build --strict`: passes (verified locally with the social-card plugin disabled, since it needs Cairo which is preinstalled on CI runners; CI runs strict with Cairo present).
- `pytest`: 610 passed, 1 skipped, 100% coverage.
- `ruff check .` / `ruff format --check .`: clean (79 files). `mypy httptap`: success, no issues.

## Screenshots/Output

```
$ uv run pytest
610 passed, 1 skipped in 3.41s
TOTAL                                  1467      0    372      0   100%

$ uv run mkdocs build --strict
INFO - mkdocs_static_i18n: Building 'zh' documentation ...
INFO - mkdocs_static_i18n: Translated 22 navigation elements to 'zh'
INFO - Documentation built in ~3s
```

## Checklist

- [x] My code follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
- [x] I have run `uv run ruff check .` and `uv run ruff format .`
- [x] I have run `uv run mypy httptap` and resolved type errors
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — no runtime behaviour changed)
- [x] All tests pass locally: `uv run pytest`
- [x] I have updated the documentation (if applicable)
- [x] I have added docstrings to new functions/classes
- [x] My changes don't introduce new dependencies (or I've justified them) — the five new packages are docs-only (`[dependency-groups] docs`) and add nothing to the runtime/install footprint
- [ ] I have checked that my changes work on multiple platforms (if applicable) — docs build only, CI covers Linux

## Breaking Changes

None. Documentation, docstrings, docs dependencies and the docs CI workflow only; no runtime code or public API behaviour changes.

**Impact:**
n/a

**Migration:**
n/a

## Additional Context

Two items were intentionally left out for a maintainer decision: the `Last reviewed` date in `security/assurance-case.md` (bumping it would assert a security review that did not happen) and the GitKraken promo block on `index.md`.
