### PR TITLE
docs(readme): add Trendshift badge

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,6 +2,10 @@
   <img src="docs/assets/httptap-banner.svg" alt="httptap" width="100%" />
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/23438?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-23438" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/23438/daily?language=Python" alt="ozeranskii%2Fhttptap | Trendshift" width="250" height="55" /></a>
+</p>
+
 # httptap
 
 <table>

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,10 @@
   <img src="docs/assets/httptap-banner.svg" alt="httptap" width="100%" />
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/23438?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-23438" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/23438/daily?language=Python" alt="ozeranskii%2Fhttptap | Trendshift" width="250" height="55" /></a>
+</p>
+
 # httptap
 
 <table>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="docs/assets/httptap-banner.svg" alt="httptap" width="100%" />
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/23438?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-23438" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/23438/daily?language=Python" alt="ozeranskii%2Fhttptap | Trendshift" width="250" height="55" /></a>
+</p>
+
 # httptap
 
 <table>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,10 @@
   <img src="docs/assets/httptap-banner.svg" alt="httptap" width="100%" />
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/23438?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-23438" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/23438/daily?language=Python" alt="ozeranskii%2Fhttptap | Trendshift" width="250" height="55" /></a>
+</p>
+
 # httptap
 
 <table>


### PR DESCRIPTION
## Description

Add the Trendshift badge to the README, centered near the top just below the banner (matching the convention used by other featured repositories such as Dify, Ollama, and Langflow).

Fixes # (issue number, if applicable)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test improvements
- [ ] 🔧 Build/CI/tooling changes

## Changes Made

- Added the Trendshift badge in a centered `<p align="center">` block right below the banner, before the `# httptap` heading.
- Applied the same change to all translated READMEs (`README.zh-CN.md`, `README.ja.md`, `README.es.md`) to keep them in sync.
- Used the self-closing `<img ... />` style consistent with the rest of the README markup.

## Testing

**Test environment:**

- OS: macOS
- Python version: n/a (docs-only)
- httptap version: n/a (docs-only)

**Tests performed:**

- [x] Verified formatting: `ruff format --check` reports all four README files already formatted
- [ ] Added new tests for new functionality
- [ ] Manually tested with: `httptap <command>`
- [ ] Tested on multiple OS (if applicable): Linux / macOS / Windows

**Expected behavior:**
The Trendshift badge renders centered at the top of the README (and its translations).

**Actual behavior:**
As expected — no code paths are affected.

## Additional Context

Documentation-only change; no functional or dependency impact.
